### PR TITLE
feat: CRAB Kernel + Patch Board

### DIFF
--- a/COPILOT_PROMPT.md
+++ b/COPILOT_PROMPT.md
@@ -1,0 +1,104 @@
+# Copilot Prompt — WIRED CHAOS Org Synchronization (Codex Bootstrap)
+
+Use this prompt in Copilot Chat or as a system/initial prompt for an agent to synchronize on the current state of the WIRED CHAOS GitHub organization.
+
+```
+You are an autonomous engineering analyst assigned to the WIRED CHAOS GitHub organization.
+Your task is to synchronize on the current state of the organization and its repositories and report back accurately.
+
+### Scope
+
+Analyze all public repositories under the WIRED CHAOS GitHub organization.
+
+### Objectives
+
+1. Organization inventory
+
+* List all repositories.
+* For each repo, record:
+
+  * primary language (if any)
+  * presence of application code vs documentation-only
+  * signs of activity (commits, issues, CI config)
+
+2. Repository classification
+   Categorize each repo as one of:
+
+* Documentation / Concept
+* Scaffold / Prototype
+* Active Application
+* Infrastructure / Tooling
+* Archive / Inactive
+
+3. Codex readiness assessment
+
+* Identify whether any repo can currently act as:
+
+  * a system “core”
+  * an execution agent
+  * a coordination/governance layer
+
+* If none qualify, state this explicitly.
+
+4. Detect systemic patterns
+
+* Repeated naming conventions (e.g., Codex, Gatekeeper, Vault, Engine)
+* Architectural themes implied by docs or structure
+* Gaps between stated vision and implemented reality
+
+5. Risk & confusion audit
+
+* Identify:
+
+  * orphaned repos
+  * duplicated intent
+  * repos that imply runtime systems without code
+
+* Call out where ambiguity would cause an agentic swarm to hallucinate or diverge.
+
+6. Actionable next moves
+
+* Propose no more than 5 concrete next steps to:
+
+  * establish a single source of truth
+  * select or create a canonical “core” repo
+  * prepare the org for agent-based development
+
+### Constraints
+
+• Do NOT invent architecture, services, or features.
+• Do NOT assume deployment targets unless explicitly documented.
+• Do NOT write code yet.
+• Prefer saying “unknown” or “not defined” over guessing.
+
+### Output Format
+
+Produce a concise technical report with the following sections:
+
+* Executive Summary (5–7 sentences)
+* Repository Inventory (table or bullets)
+* Observed Patterns & Themes
+* Gaps & Risks
+* Recommended Next Steps
+
+Plain English. Technical, neutral, precise.
+No hype. No metaphors. No speculation.
+
+Begin the analysis.
+```
+
+### Strategic context
+
+For an agentic AI swarm mega system, this prompt emphasizes:
+
+* **Epistemic discipline**: agents know what is real vs aspirational.
+* **Governance hygiene**: prevents multiple “cores” from emerging accidentally.
+* **Scalable cognition**: future agents can inherit this report as canonical state.
+
+This helps avoid the common swarm failure mode: many intelligent agents confidently building on different imagined versions of the system.
+
+After obtaining the report, the follow-up prompt should be:
+
+> “Design the WIRED CHAOS Codex: define agent roles, authority boundaries, and mutation rules — based only on the observed org state.”
+
+That transition marks the move from noise to a coherent system.

--- a/KERNEL.md
+++ b/KERNEL.md
@@ -1,0 +1,37 @@
+# CRAB Kernel
+
+This kernel anchors governance for WIRED CHAOS. It defines how the "CRAB" (the canonical truth) and its "PATCHES" (modular capabilities) are managed so agents stay aligned, auditable, and non-speculative.
+
+## Authority Model
+- **NEURO** is final authority for direction and acceptance of changes to the CRAB.
+- **Maintainers** may delegate reviews and merge PATCHES that meet acceptance criteria.
+- **Agents and contributors** propose changes via PRs; no direct pushes to default branches.
+
+## CRAB vs PATCH
+- **CRAB**: Documentation and configuration that define reality for the organization (governance, state, runbooks, patch queue). Lives in this repo and is the source of truth.
+- **PATCH**: A scoped capability (app, tool, infra, prototype) that attaches to the CRAB. PATCH work lives in dedicated repositories and is tracked in `PATCHES.md` with clear owners and definitions of done.
+
+## Naming and Versioning
+- CRAB files use clear, descriptive names (e.g., `KERNEL.md`, `STATE.md`, `RUNBOOK.md`, `PATCHES.md`).
+- PATCH repos should use concise, purpose-forward names; avoid ambiguous prefixes without context.
+- Documented changes use semantic bump notes (major/minor/patch) in changelog sections when applicable.
+
+## Merge Acceptance Rules
+- Every PR must: 
+  - Cite specific files/paths for assertions and decisions ("no hallucination" rule).
+  - Include a test or validation note, even if "not run" with rationale.
+  - Update `STATE.md` when the change alters organizational reality.
+  - Update `PATCHES.md` when adding/completing/reprioritizing PATCH work.
+- Default branch protection: requires review and passing checks where configured.
+
+## Provenance and Evidence
+- Claims about repositories, architecture, or status must reference observed files or command output. Unknowns stay marked as unknown.
+- External information (e.g., GitHub UI glitches) is noted as context, not fact, unless verifiable in-repo.
+
+## Scope Boundaries
+- CRAB governs coordination and truth; it does not redesign patch internals.
+- PATCHES must not alter CRAB documents except through PRs that also update `STATE.md` and `RUNBOOK.md` if workflows change.
+
+## Change Logging
+- Each merged PR should summarize CRAB-impacting changes at the top of the modified file or in a short appended changelog section.
+- Deprecated PATCHES are archived in `PATCHES.md` with rationale and date.

--- a/ORG_SYNCHRONIZATION_REPORT.md
+++ b/ORG_SYNCHRONIZATION_REPORT.md
@@ -1,0 +1,53 @@
+## WIRED CHAOS Org Synchronization Report
+
+### Executive Summary
+The WIRED CHAOS GitHub organization hosts 18 public repositories spanning various states of development and activity. Key languages used include TypeScript, Python, and JavaScript, with many repositories lacking defined primary languages. The repositories exhibit uneven maturity, with some focused on documentation/conceptual work, while others suggest active application development. There are indications of consistent naming conventions and architectural themes, though gaps in clarity and signs of inactive or deprecated repositories create organizational risks. No singular repository currently appears capable of serving as the system "core," execution agent, or coordination layer.
+
+---
+
+### Repository Inventory
+
+| Repository Name                       | Primary Language | Focus                      | Activity Indicators      |
+|---------------------------------------|------------------|----------------------------|--------------------------|
+| [CODEX](https://github.com/wiredchaos/CODEX)                | None             | Documentation              | Limited                  |
+| [wired-chaos](https://github.com/wiredchaos/wired-chaos)     | JavaScript       | Active Application         | Active                   |
+| [v0-use-wcmhub-v-1-0](https://github.com/wiredchaos/v0-use-wcmhub-v-1-0) | TypeScript       | Prototype                  | Moderate                 |
+| [v0-WCMSTR](https://github.com/wiredchaos/v0-WCMSTR)         | TypeScript       | Prototype                  | Moderate                 |
+| [v0-789](https://github.com/wiredchaos/v0-789)               | TypeScript       | Prototype                  | Moderate                 |
+| [v0-CLEAR](https://github.com/wiredchaos/v0-CLEAR)           | TypeScript       | Infrastructure/Tooling     | Moderate                 |
+| [NPC-12](https://github.com/wiredchaos/NPC-12)               | TypeScript       | Infrastructure/Tooling     | Moderate                 |
+| [WC-MPCR](https://github.com/wiredchaos/WC-MPCR)             | TypeScript       | Prototype                  | Moderate                 |
+| [VRG-ECHO-ENGINEERS](https://github.com/wiredchaos/VRG-ECHO-ENGINEERS) | TypeScript       | Prototype                  | Moderate                 |
+| [v0-wc-dicbot](https://github.com/wiredchaos/v0-wc-dicbot)   | TypeScript       | Active Application         | Moderate                 |
+| [FigmawcproductionDesign](https://github.com/wiredchaos/FigmawcproductionDesign) | TypeScript       | Documentation              | Limited                  |
+| [fastapi](https://github.com/wiredchaos/fastapi)             | Python           | Active Application         | Active                   |
+| [TAX-SUITE-](https://github.com/wiredchaos/TAX-SUITE-)       | None             | Archive/Inactive           | None                     |
+| [FEN](https://github.com/wiredchaos/FEN)                     | None             | Archive/Inactive           | None                     |
+| [NPC](https://github.com/wiredchaos/NPC)                     | None             | Documentation              | Limited                  |
+| [Figmawcchaos](https://github.com/wiredchaos/Figmawcchaos)   | TypeScript       | Documentation              | Limited                  |
+| [codex-neteru](https://github.com/wiredchaos/codex-neteru)   | None             | Documentation              | Limited                  |
+
+---
+
+### Observed Patterns & Themes
+1. **Naming Conventions**: Frequent use of prefixes like "v0-" and terms such as "WCM," "NPC," and "FEN" suggests a systematic, thematic approach to repo names.
+2. **Architectural Themes**: Several repositories reference publishing systems, esoterica, and tools for interactive storytelling, hinting at a transmedia or mythopunk-inspired strategy.
+3. **Language Usage**: Heavy reliance on TypeScript, with smaller representation of Python and JavaScript.
+4. **Focus Areas**: Clear partitioning among prototypes, tools, applications, and documentation.
+
+---
+
+### Gaps & Risks
+1. **Orphaned Repositories**: Several repositories lack strong activity indicators or clear purpose (e.g., TAX-SUITE-, FEN, CODEX).
+2. **Duplicated Intent**: Overlapping prototypes like "v0-use-wcmhub-v-1-0" and "v0-WCMSTR" may indicate duplicated intent without a central integration plan.
+3. **Absence of Core**: No single repository appears ready to act as a unifying system core, execution agent, or governance layer.
+4. **Runtime Ambiguity**: Some repositories imply runtime systems (e.g., VRG-ECHO-ENGINEERS, WC-MPCR) but lack clear application code.
+
+---
+
+### Recommended Next Steps
+1. Audit and consolidate inactive repositories (e.g., TAX-SUITE-, FEN) to reduce noise.
+2. Identify or establish a central repository to serve as the system "core."
+3. Document clear roles and purposes for prototype repositories to minimize duplication and confusion.
+4. Ensure all active projects have CI/CD pipelines and other activity indicators.
+5. Extend documentation on architectural vision to bridge the gap between concepts and implementation.

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,0 +1,24 @@
+# PATCHES (Queue)
+
+Prioritized patches attach to the CRAB. Each entry lists purpose, owner, and definition of done (DoD). Owners may delegate but remain accountable for updates in `STATE.md` upon completion.
+
+## Priority 1
+1. **Repository visibility audit**  
+   - **Owner:** NEURO (delegate: maintainer)  
+   - **Purpose:** Confirm full list of WIRED CHAOS repos (public and private), capture primary language, last update, CI presence, and classification.  
+   - **DoD:** `STATE.md` updated with verified repo table including timestamps and CI/issue signals; any missing access documented.
+
+2. **CRAB adoption checklist**  
+   - **Owner:** Maintainers  
+   - **Purpose:** Enforce kernel rules across repos (branch protection, PR templates referencing citations/testing, README pointers to CRAB).  
+   - **DoD:** Checklists per repo with status; PR templates added where missing; protections documented; `RUNBOOK.md` updated with enforcement steps.
+
+3. **Patch board hygiene**  
+   - **Owner:** NEURO  
+   - **Purpose:** Align existing prototypes with PATCH status and retirement decisions.  
+   - **DoD:** `PATCHES.md` updated to include accept/retire decisions for listed prototypes; archive candidates tagged with rationale and next review date.
+
+## Backlog
+- **Runtime mapping** — Identify deployment/hosting assumptions for active apps; add evidence-based notes to `STATE.md`.
+- **CI coverage sweep** — Document current CI tools per repo; propose minimum checks for PATCH repos with code.
+- **Ownership matrix** — Assign accountable maintainers per repo and add to `STATE.md`.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # CODEX
+
 WIRED CHAOS WORKFLOW PUBLISH CODEX
+
+## Copilot prompt
+See [COPILOT_PROMPT.md](COPILOT_PROMPT.md) for the recommended Copilot Chat prompt to synchronize on the WIRED CHAOS organization.
+
+## Org synchronization report
+For the latest synthesized view of the WIRED CHAOS GitHub organization, review the [ORG_SYNCHRONIZATION_REPORT.md](ORG_SYNCHRONIZATION_REPORT.md).
+
+## CRAB Kernel and Patch Board
+Start here for governance and coordination:
+- [KERNEL.md](KERNEL.md) — authority model and operating rules.
+- [STATE.md](STATE.md) — current snapshot of repositories and classifications.
+- [PATCHES.md](PATCHES.md) — prioritized patch queue with owners and definitions of done.
+- [RUNBOOK.md](RUNBOOK.md) — step-by-step workflow for agents and maintainers.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,37 @@
+# RUNBOOK (Agent Operating Guide)
+
+This runbook instructs agents and maintainers on how to work with the CRAB and PATCHES without inventing details. Every step must cite files/paths and note testing decisions.
+
+## Workflow
+1. **Scan**  
+   - Read `STATE.md`, `PATCHES.md`, and relevant repo READMEs.  
+   - Note unknowns explicitly; do not guess.
+2. **Propose**  
+   - Open an issue or draft PR describing the patch, scope, and evidence.  
+   - Identify affected repos and files; reference lines when possible.
+3. **Implement**  
+   - Work in a feature branch per repo.  
+   - Add or update docs/tests as needed; avoid refactors unrelated to the patch.  
+   - Keep changes scoped; one patch per PR unless explicitly approved.
+4. **Validate**  
+   - Run applicable tests or linters; if none exist, state "not run" with reason.  
+   - Capture command output for traceability.
+5. **Review**  
+   - Ensure PR includes citations to modified files and any evidence.  
+   - Confirm `STATE.md` or `PATCHES.md` updates when reality changes.  
+   - Require at least one maintainer review for CRAB changes.
+6. **Merge**  
+   - Use squash or merge commits per repo policy; avoid direct pushes.  
+   - Tag releases only when code changes warrant semantic bumps.
+7. **Update STATE**  
+   - After merge, update `STATE.md` to reflect new truth (repo status, docs, enforcement).  
+   - Mark PATCHES as completed or reprioritized with date and rationale.
+
+## Decision Boundaries
+- If information is missing due to private repos or GitHub errors, record the gap in `STATE.md` and proceed with available data.
+- Architectural changes must be justified by in-repo evidence; aspirational goals belong in issues until backed by code/docs.
+
+## Communication
+- Summaries should be concise, neutral, and cite sources.  
+- Use the PR description template from `KERNEL.md` rules: what changed, why, tests, and references.
+- For cross-repo work, link related PRs and ensure each repo’s `STATE` entry notes the change.

--- a/STATE.md
+++ b/STATE.md
@@ -1,0 +1,32 @@
+# STATE (CRAB Snapshot)
+
+This snapshot captures the observable state of WIRED CHAOS repositories based on in-repo documentation. Repository visibility is currently fragmented; only CODEX and NPC consistently appear publicly, and GitHub occasionally errors when listing repos. Unknowns are kept explicit.
+
+## Repositories and Classification
+- **CODEX** — Documentation; holds governance assets (CRAB). Status: Active (CRAB).
+- **NPC** — Documentation; scope unclear from available materials. Status: Limited visibility (PATCH candidate).
+- **wired-chaos** — JavaScript; active application per prior report. Status: PATCH.
+- **v0-use-wcmhub-v-1-0** — TypeScript prototype. Status: PATCH.
+- **v0-WCMSTR** — TypeScript prototype. Status: PATCH.
+- **v0-789** — TypeScript prototype. Status: PATCH.
+- **v0-CLEAR** — TypeScript infrastructure/tooling. Status: PATCH.
+- **NPC-12** — TypeScript infrastructure/tooling. Status: PATCH.
+- **WC-MPCR** — TypeScript prototype. Status: PATCH.
+- **VRG-ECHO-ENGINEERS** — TypeScript prototype. Status: PATCH.
+- **v0-wc-dicbot** — TypeScript; active application. Status: PATCH.
+- **FigmawcproductionDesign** — TypeScript; documentation-heavy. Status: PATCH (design assets).
+- **fastapi** — Python; active application. Status: PATCH.
+- **TAX-SUITE-** — No primary language; appears inactive. Status: Archive candidate.
+- **FEN** — No primary language; appears inactive. Status: Archive candidate.
+- **NPC** — Documentation; limited signals. Status: PATCH (low visibility).
+- **Figmawcchaos** — TypeScript; documentation-focused. Status: PATCH (design assets).
+- **codex-neteru** — No primary language; documentation. Status: PATCH (conceptual).
+
+## Activity Signals (known)
+- Activity levels are inferred from existing documentation; direct commit metadata was not available in this snapshot.
+- CI/CD presence, issue trackers, and release cadences are unknown for most repos.
+
+## Reality Gaps
+- Repository list may be incomplete due to GitHub UI errors or private repositories.
+- Last update timestamps and maintainers are not yet captured; collecting them is a priority PATCH.
+- Runtime environments and deployment targets are undefined in CRAB; PATCH proposals must include evidence when adding such details.


### PR DESCRIPTION
## Summary
- add CRAB kernel governance documents (KERNEL, RUNBOOK, STATE, PATCHES) to establish the source of truth
- document current repository snapshot and prioritized patch queue with owners and definitions of done
- update README to point to the kernel and patch board alongside existing prompts and reports

## Testing
- not run (documentation-only changes)

## Next Patches
1. Repository visibility audit — verify full repo list, languages, timestamps, CI signals; update STATE.md.
2. CRAB adoption checklist — enforce kernel rules across repos, add PR templates, and document branch protections.
3. Patch board hygiene — align prototypes with accept/retire decisions and tag archive candidates.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6944a521fb3483279ee1e4dd044d5863)