### PR TITLE
Add fashion design swarm brief

### DIFF
--- a/FASHION_DESIGN_SWARM.md
+++ b/FASHION_DESIGN_SWARM.md
@@ -1,0 +1,87 @@
+# WIRED CHAOS META — FASHION DESIGN SWARM (FDS-1)
+
+Purpose: Onboard Web2 fashion designers into Web3 by teaching design, 3D, code, and on-chain commerce simultaneously, using dripONchain™ as the live laboratory. This is not a course; it is on-the-job training inside a simulated decentralized economy.
+
+## 1. Swarm Architecture
+
+| Agent | Role |
+| --- | --- |
+| FDS-ARCHON | Master curriculum and progression controller |
+| CUTMASTER | Patternmaking and garment construction logic |
+| TEXTILE-AI | Fabric physics, materials, shaders |
+| DRAPE-ENGINE | CLO/Blender/Marvelous Designer logic |
+| AVATAR-FORGE | Wearable compatibility and rigging |
+| CHAIN-LOOM | NFT traits, DOGE inscriptions, mint logic |
+| MERCH-VAULT | Bookstore and dripONchain commerce |
+| RUNWAY-SIM | Virtual runway and OTT integration |
+| FASHION-BOT | Discord/Telegram mentor and critiques |
+
+All agents report into NEURO BRAIN.
+
+## 2. Curriculum (FIDM → WIRED CHAOS Upgrade)
+
+### Year 1 — Foundations (Web2 → Web3)
+- **FDS-101: Fashion Fundamentals** — Silhouette theory; proportion and balance; historical references (abstracted, non-geopolitical).
+- **FDS-102: Color, Texture and Form** — Color systems; material behavior; digital textile logic.
+- **FDS-103: Pattern Logic** — Flat vs. 3D patterns; parametric garment systems.
+- **In-Game Output:** Unlocked base garment traits (Common); minted as non-tradable prototypes.
+
+### Year 2 — 3D and Avatar Wearables
+- **FDS-201: 3D Garment Construction** — CLO/Blender workflows; physics-driven drape.
+- **FDS-202: Avatar Fit Systems** — Body-agnostic fitting; modular wearable slots.
+- **FDS-203: Rigging and Skin Weights** — Game-ready assets; performance optimization.
+- **In-Game Output:** Wearable NFTs (upgradeable); traits unlocked via skill performance, not RNG.
+
+### Year 3 — Code and Generative Fashion
+- **FDS-301: Code-Driven Design** — Parametric garments; trait-based generation; logic-based rarity (not random).
+- **FDS-302: Dynamic Fashion NFTs** — Mutable metadata; burn-to-upgrade mechanics; layer-based evolution (333 / 589 / 999).
+- **FDS-303: Fashion Systems Engineering** — Supply chains; digital-to-physical mirroring.
+- **In-Game Output:** Dynamic wearables; upgradeable through gameplay plus CHAOS_CREDITS.
+
+### Year 4 — Commerce and Runway
+- **FDS-401: dripONchain™ Economy** — Pricing models; scarcity logic; drop strategy.
+- **FDS-402: University Bookstore Mirror** — Each school = unique merch; digital plus phygital SKUs.
+- **FDS-403: Runway Simulation** — Virtual shows; 789 Studios OTT broadcasts.
+- **Capstone Output:** Designer Vault; royalty-enabled collections; DOGE inscription master pieces.
+
+## 3. Minting and Trait Mechanics
+- No random mint.
+- Traits unlocked by skill, XP, behavioral performance, and burn events.
+- **NFT Structure:** Base NFT = shell; traits are layered, purchasable, and earnable; burn artifacts to unlock next tier; each layer requires all artifacts to advance.
+- **Numerology Enforcement:** 333 / 589 / 999 only; Fibonacci rarity curves; no exceptions.
+
+## 4. Blockchain Rules
+- Mint chain: DOGE (inscriptions).
+- Accepted payments: all listed.
+- Payouts: fiat or DOGE only.
+- Fees: minimal chains only.
+- Vault: 3% fee → DCA engine.
+- Wallet: Starbucks-style internal balance.
+- Seed phrase loss carries real consequences by design.
+
+## 5. Discord / Telegram Fashion Bot
+- Capabilities: design critiques; trait unlock notifications; drop countdowns; vault balance alerts; mentor feedback loops.
+- Behavior: acts like a studio professor, not a chatbot.
+
+## 6. Funnel (Built-In)
+1. Free design challenge.
+2. Unlock prototype wearable.
+3. Enter dripONchain lab.
+4. Earn → Mint → Upgrade.
+5. Graduate to paid drops.
+6. Optional DFY / Studio access.
+
+## 7. Name and Brand
+- Program name: **dripONchain™ Fashion Lab**.
+- Tone: high fashion × cyber × artisan × future.
+- No race labels; diversity expressed through form, texture, light, shadow, and energy.
+- Dark skin + purple eyes framed as aesthetic power, not identity tagging.
+
+## 8. Next Execution (PM Locked)
+- Fashion Trait Catalog Expansion (500+ traits).
+- 3D Mockup Automation Swarm.
+- University Bookstore Engine.
+- Runway OTT Module for 789 Studios.
+- Designer Vault Dashboard.
+
+PM lead: WIRED CHAOS META.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ See [COPILOT_PROMPT.md](COPILOT_PROMPT.md) for the recommended Copilot Chat prom
 ## Org synchronization report
 For the latest synthesized view of the WIRED CHAOS GitHub organization, review the [ORG_SYNCHRONIZATION_REPORT.md](ORG_SYNCHRONIZATION_REPORT.md).
 
+## Fashion Design Swarm
+The [FASHION_DESIGN_SWARM.md](FASHION_DESIGN_SWARM.md) brief captures the FDS-1 onboarding blueprint for bringing Web2 fashion designers into the dripONchain™ lab.
+
 ## CRAB Kernel and Patch Board
 Start here for governance and coordination:
 - [KERNEL.md](KERNEL.md) — authority model and operating rules.


### PR DESCRIPTION
## Summary
- add the FASHION_DESIGN_SWARM.md brief outlining the FDS-1 architecture, curriculum, mechanics, and execution roadmap
- link the new brief from the repository README for discoverability

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6944c6d2aef083278353bbdbf07fdb49)