### PR TITLE
Define 3DT consumer governance

### DIFF
--- a/3DT_CONSUMER_CONTRACT.md
+++ b/3DT_CONSUMER_CONTRACT.md
@@ -1,0 +1,35 @@
+# 3DT Consumer Contract (Plain Language)
+
+If you create anything named with the `-3DT` suffix, you are building a **consumer** that runs on the Wired Chaos platform. This contract explains what you automatically get and what you must follow.
+
+## What you inherit automatically
+- **Platform runtime**: Your project runs on the Wired Chaos runtime. You do not ship your own runtime.
+- **Registry**: Discovery, configuration, and artifact references are handled by the Wired Chaos registry.
+- **Permissions**: Authentication and authorization are enforced by the platform. You use the platform controls; you do not add your own gatekeepers.
+- **Environment**: Deployment, logging, observability, and safety rails come from the platform environment.
+
+## Lifecycle expectations
+- `-3DT` projects are onboarded into the platform lifecycle: deployment, monitoring, incident response, and rollback are managed through platform tools.
+- Changes to your project must respect platform change windows and rollout rules.
+- Platform deprecations and security updates apply to you automatically; you must adapt before deadlines to avoid disruption.
+
+## Versioning and upgrades
+- The platform publishes runtime, registry, permissions, and environment versions. Your project must stay compatible with the supported versions.
+- When a platform version is marked for upgrade, you are expected to validate your project against the new version and follow the prescribed upgrade path.
+- If you need features or fixes, you request them through platform channels; you do not fork the platform to move faster.
+
+## What you may do
+- Build and evolve your experience logic, assets, and configurations that plug into the platform.
+- Document how operators should run and support your experience within the platform boundaries.
+- Use approved platform interfaces to call services or respond to events.
+
+## What you may not do
+- Replace or bypass the Wired Chaos runtime, registry, permissions, or environment.
+- Define your own governance, ownership, or security rules that conflict with the platform.
+- Implement rendering or WebGPU pipelines outside the platform. Consumers do not supply rendering engines.
+
+## Ownership boundaries
+- Wired Chaos owns and operates the runtime, registry, permissions, environment, and upgrade cadence.
+- Consumer teams own their content, logic, and correctness within the platform. They must remain compatible with platform policies and timelines.
+
+By using the `-3DT` suffix, you agree that your project is a Wired Chaos consumer and that these platform expectations apply.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Start here for governance and coordination:
 - [TRINITY_REQUIRED_PIECES.md](TRINITY_REQUIRED_PIECES.md) — checklist placeholder for required components.
 - [TRINITY_GAPS_NEXT_ACTIONS.md](TRINITY_GAPS_NEXT_ACTIONS.md) — missing evidence and next documentation steps.
 
+## 3DT Consumer Model
+All projects ending in `-3DT` are consumers of the Wired Chaos platform. They rely on the platform runtime, registry, permissions, and environment; they do not replace or fork those systems. See:
+- [TRINITY_CONSUMERS.md](TRINITY_CONSUMERS.md) for the formal definition and boundaries.
+- [3DT_CONSUMER_CONTRACT.md](3DT_CONSUMER_CONTRACT.md) for the plain-language contract every `-3DT` project inherits.
+
+
 ## How uploads work
 Uploads are drop-only: place `.zip` files in `INBOX_UPLOADS/` via **Add file → Upload files**, commit, then let automation unpack, update docs, and open a PR. Check the latest **Ingest Vercel ZIP exports** run in the **Actions** tab and review the PR for extracted files and refreshed audit docs.
 

--- a/TRINITY_CONSUMERS.md
+++ b/TRINITY_CONSUMERS.md
@@ -1,0 +1,33 @@
+# Trinity 3DT Consumers
+
+This document clarifies that any project with a name ending in `-3DT` is a **consumer** of the Wired Chaos platform. These projects are not standalone runtimes; they rely on the shared platform services to operate in production.
+
+## What is a 3DT consumer?
+A 3DT consumer is an application, experience, or asset bundle that plugs into the Wired Chaos platform. It expects the platform to provide runtime execution, registry lookups, permission controls, and the environment needed to run safely. The consumer supplies its own content and behavior within those boundaries but does not replace or fork the platform.
+
+## Platform dependencies for all `*-3DT` projects
+Every project ending in `-3DT`:
+- **Uses the Wired Chaos runtime** for execution, orchestration, and lifecycle management.
+- **Relies on the Wired Chaos registry** for discovery, configuration, and artifact resolution.
+- **Depends on Wired Chaos permissions** for authentication, authorization, and policy enforcement.
+- **Runs inside the Wired Chaos environment** for deployment, observability, logging, and safety rails.
+
+These dependencies are mandatory and non-optional; a `-3DT` project cannot run without the platform.
+
+## What 3DT consumers may define
+- Domain logic specific to the experience or asset (scenes, interactions, data mappings).
+- Integration contracts that call into approved platform interfaces.
+- Configuration values that the platform reads to wire the experience (e.g., feature flags, asset references).
+- Documentation for operators and users of the experience.
+
+## What 3DT consumers may not define
+- Replacement runtimes, registries, or permission systems.
+- Alternative environment or deployment stacks that bypass the Wired Chaos platform.
+- Platform governance, ownership, or security rules.
+- Rendering or WebGPU pipelines; those are provided by the platform and must not be reimplemented here.
+
+## Ownership and responsibility
+- **Platform**: owns runtime stability, registry integrity, permission enforcement, environment safety, and upgrade cadence.
+- **Consumer teams**: own their experience logic, assets, and adherence to platform contracts. They must keep their integrations compatible with platform versioning and follow platform deprecation notices.
+
+By declaring `-3DT` status, a project opts into the consumer role and accepts these dependencies and boundaries.


### PR DESCRIPTION
## Summary
- formalize the `-3DT` consumer role and platform dependencies in TRINITY_CONSUMERS.md
- add a plain-language 3DT consumer contract covering inheritance, lifecycle, and upgrade expectations
- update README with 3DT Consumer Model section linking to the governance documents

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69450e6435908327a0c47e5d06858ac8)