### PR TITLE
Add canonical WIRED CHAOS exports summary

### DIFF
--- a/_exports/AGENTS_AND_PATCHES.md
+++ b/_exports/AGENTS_AND_PATCHES.md
@@ -1,0 +1,26 @@
+# Agents and Patch Registry
+
+## Governance Agents
+- **NEURO (authority)** — Final decision-maker for CRAB changes and PATCH acceptance.【F:KERNEL.md†L1-L20】 Inputs: PRs with evidence; Outputs: approvals/merge decisions.
+- **Maintainers** — May delegate reviews and merge PATCHES if criteria met; enforce citation/testing rules.【F:KERNEL.md†L8-L29】【F:RUNBOOK.md†L1-L33】
+- **Contributors/Agents** — Propose changes via PRs; must follow RUNBOOK steps and cite evidence.【F:KERNEL.md†L8-L33】【F:RUNBOOK.md†L1-L33】
+
+## Patch Board (CRAB-aligned)
+- **PATCHES.md** queue lists prioritized work: repository visibility audit, CRAB adoption checklist, patch board hygiene; backlog includes runtime mapping, CI sweep, ownership matrix.【F:PATCHES.md†L1-L23】 Inputs: repo evidence; Outputs: updated STATE/PATCHES tables.
+- **Patch Naming** — Patch identifiers appear as repo names (e.g., `v0-CLEAR`, `NPC-12`, `v0-789`) and are tracked as PATCH candidates in `STATE.md`. No code naming convention beyond repo name prefixes observed.【F:STATE.md†L1-L33】
+
+## Automation Agents (Workflows)
+- **vercel_zip_sorter** (`.github/workflows/vercel_zip_sorter.yml`) — Moves ZIPs from root/INBOX_UPLOADS into `VERCEL_HISTORY` buckets (`exports`, `3dt`, `builds`, `misc`), updates manifest; auto-PR with manifest changes.【F:.github/workflows/vercel_zip_sorter.yml†L1-L35】 Inputs: ZIP files; Outputs: moved archives, `_MANIFEST.json` entries.
+- **vercel_zip_ingest** (`.github/workflows/vercel_zip_ingest.yml`) — Unpacks ZIPs from `INBOX_UPLOADS`, scans transcripts for Trinity keywords, updates audit docs and run summary, opens PR.【F:.github/workflows/vercel_zip_ingest.yml†L1-L48】【F:scripts/vercel_zip_ingest.py†L1-L120】 Inputs: ZIP archives; Outputs: `CRAB_LEGS_INDEX.md`, `TRINITY_INSTALL_CATALOG.md`, `TRINITY_GAPS_NEXT_ACTIONS.md`, manifest JSON.
+- **vercel_zip_safety** (`.github/workflows/vercel_zip_safety.yml`) — PR guard commenting if ZIPs exist outside `INBOX_UPLOADS/`.【F:.github/workflows/vercel_zip_safety.yml†L1-L44】 Inputs: PR file list; Outputs: warning comments.
+
+## Swarm Roles (Program Briefs)
+- **FASHION DESIGN SWARM Agents** — Roles include FDS-ARCHON (curriculum control), CUTMASTER (pattern logic), TEXTILE-AI (materials), DRAPE-ENGINE (3D drape physics), AVATAR-FORGE (rigging), CHAIN-LOOM (NFT traits/DOGE inscriptions), MERCH-VAULT (commerce), RUNWAY-SIM (runway/OTT), FASHION-BOT (mentor/alerts). All report to NEURO BRAIN.【F:FASHION_DESIGN_SWARM.md†L6-L35】 Inputs: designer performance data, trait unlock events; Outputs: training progression, NFT mint triggers, commerce alerts.
+
+## Registries and Routers
+- **CRAB_LEGS_INDEX.md** — Intended transcript registry; currently empty pending uploads.【F:CRAB_LEGS_INDEX.md†L1-L18】 Inputs: Vercel transcripts; Outputs: indexed legs with Trinity indicators.
+- **TRINITY_INSTALL_CATALOG.md** — Status router summarizing Trinity evidence by repo and transcript; currently marked missing.【F:TRINITY_INSTALL_CATALOG.md†L1-L31】 Inputs: transcript scans; Outputs: repo/leg status tables.
+- **scripts/vercel_zip_sorter.py** — Internal classifier routing ZIPs into buckets based on filename heuristics, ensuring non-overwrite paths and manifest updates.【F:scripts/vercel_zip_sorter.py†L1-L80】 Inputs: ZIP files; Outputs: relocated files + manifest entries.
+
+## Isolation / Firewall Rules
+- No explicit sandboxing rules beyond PR-based governance; safety workflow enforces ZIP location to prevent arbitrary file placement.【F:.github/workflows/vercel_zip_safety.yml†L1-L44】 Agents must avoid CRAB document edits without evidence per RUNBOOK/KERNEL.

--- a/_exports/DEPLOYMENT.md
+++ b/_exports/DEPLOYMENT.md
@@ -1,0 +1,23 @@
+# Build / Deployment Surface
+
+## Tooling & Automation
+- **GitHub Actions**: three workflows handle ZIP sorting, ingest, and safety checks (Python 3.11 runners).【F:.github/workflows/vercel_zip_sorter.yml†L1-L35】【F:.github/workflows/vercel_zip_ingest.yml†L1-L48】【F:.github/workflows/vercel_zip_safety.yml†L1-L44】
+- **Python Scripts**: `scripts/vercel_zip_sorter.py` classifies/moves ZIPs and writes `_MANIFEST.json`; `scripts/vercel_zip_ingest.py` unpacks archives, scans for Trinity keywords, updates CRAB docs, and emits run summaries.【F:scripts/vercel_zip_sorter.py†L1-L80】【F:scripts/vercel_zip_ingest.py†L1-L193】
+- **Vercel**: No direct config files present; workflows reference Vercel transcripts only via naming conventions.
+
+## Runtime/Monorepo Notes
+- Repository is documentation-heavy with uploaded ZIP bundles (3DT/Trinity, Akira Codex, Discord bots, tax components) awaiting automation; no compiled app targets present in working tree.
+- `VERCEL_HISTORY/` acts as storage for processed artifacts (`exports/` present; `3dt`, `builds`, `misc` created on demand).【F:CRAB_LEGS_INDEX.md†L1-L18】【F:.github/workflows/vercel_zip_sorter.yml†L1-L35】
+
+## Environment Variables / Secrets
+- Workflows rely on default `GITHUB_TOKEN`; no additional secrets/env vars declared in YAML.
+
+## Fresh Workspace Checklist
+1. Install Python 3.11+ and `pip` (for running ingest/sorter scripts manually or via Actions).【F:.github/workflows/vercel_zip_ingest.yml†L17-L24】
+2. Ensure `INBOX_UPLOADS/` exists for incoming ZIPs; run sorter to relocate archives into `VERCEL_HISTORY/*` buckets if necessary.【F:.github/workflows/vercel_zip_sorter.yml†L1-L35】【F:scripts/vercel_zip_sorter.py†L1-L80】
+3. Run `python scripts/vercel_zip_ingest.py` to unpack and refresh audit docs after uploads; check `_MANIFEST.json` and `_INGEST_RUN_SUMMARY.json` under `VERCEL_HISTORY/exports/`.【F:scripts/vercel_zip_ingest.py†L1-L193】
+4. Review regenerated `CRAB_LEGS_INDEX.md`, `TRINITY_INSTALL_CATALOG.md`, and `TRINITY_GAPS_NEXT_ACTIONS.md` for evidence updates before committing.【F:.github/workflows/vercel_zip_ingest.yml†L25-L48】
+5. Commit changes and let Actions open PRs (or push manually following RUNBOOK); ensure ZIPs remain in `INBOX_UPLOADS/` to satisfy safety checks.【F:.github/workflows/vercel_zip_safety.yml†L1-L44】【F:RUNBOOK.md†L1-L33】
+
+## Workspace Adaptation Notes
+- All evidence comes from docs and automation scaffolding; actual app builds or Vercel projects are not present. Adapting to a fresh environment primarily requires Python tooling and GitHub Actions compatibility.

--- a/_exports/DOC_INDEX.md
+++ b/_exports/DOC_INDEX.md
@@ -1,0 +1,18 @@
+# System Doc Index
+
+| Path | Title | Last Modified | Summary |
+| --- | --- | --- | --- |
+| README.md | CODEX | 2025-12-19 | Entry point linking to CRAB governance docs, org report, fashion brief, Trinity audits, and upload rules.【F:README.md†L1-L25】 |
+| COPILOT_PROMPT.md | Copilot Prompt — WIRED CHAOS Org Synchronization | 2025-12-19 | Prompt for agents to inventory org repos, classify readiness, and recommend next steps without speculation.【F:COPILOT_PROMPT.md†L1-L104】 |
+| ORG_SYNCHRONIZATION_REPORT.md | WIRED CHAOS Org Synchronization Report | 2025-12-19 | Summarizes 18 repos with languages, activity hints, themes, risks, and recommended clean-up actions.【F:ORG_SYNCHRONIZATION_REPORT.md†L1-L52】 |
+| KERNEL.md | CRAB Kernel | 2025-12-19 | Governance model defining CRAB vs PATCH roles, authority, merge rules, and evidence requirements.【F:KERNEL.md†L1-L37】 |
+| STATE.md | STATE (CRAB Snapshot) | 2025-12-19 | Current repo classifications (CRAB, PATCH, archive candidates) and noted reality gaps.【F:STATE.md†L1-L33】 |
+| PATCHES.md | PATCHES (Queue) | 2025-12-19 | Prioritized patch queue with owners, purposes, and definitions of done plus backlog items.【F:PATCHES.md†L1-L23】 |
+| RUNBOOK.md | RUNBOOK (Agent Operating Guide) | 2025-12-19 | Stepwise workflow for agents: scan, propose, implement, validate, review, merge, and update STATE/PATCHES with citations.【F:RUNBOOK.md†L1-L33】 |
+| CRAB_LEGS_INDEX.md | CRAB Legs Index (Vercel Transcripts) | 2025-12-19 | Transcript index placeholder noting no Vercel transcripts present and guidance for future legs.【F:CRAB_LEGS_INDEX.md†L1-L18】 |
+| TRINITY_INSTALL_CATALOG.md | Trinity / 3DT Install Catalog (Status Only) | 2025-12-19 | Audit summary showing no Trinity/3DT evidence, awaiting transcripts and checklist population.【F:TRINITY_INSTALL_CATALOG.md†L1-L31】 |
+| TRINITY_GAPS_NEXT_ACTIONS.md | Trinity Gaps and Next Actions | 2025-12-19 | Lists missing evidence (transcripts, indicators, checklist) and documents next steps for Trinity audits.【F:TRINITY_GAPS_NEXT_ACTIONS.md†L1-L35】 |
+| TRINITY_REQUIRED_PIECES.md | Trinity Required Pieces Checklist | 2025-12-19 | Placeholder instructing authors to define required Trinity/3DT components with evidence tracking.【F:TRINITY_REQUIRED_PIECES.md†L1-L5】 |
+| FASHION_DESIGN_SWARM.md | WIRED CHAOS META — FASHION DESIGN SWARM (FDS-1) | 2025-12-19 | Swarm-based onboarding blueprint for fashion designers covering agents, curriculum, mint rules, vault/DCA, and commerce flows.【F:FASHION_DESIGN_SWARM.md†L1-L69】 |
+| UPLOAD_CONTRACT.md | Upload Contract (Non-Developer Safe) | 2025-12-19 | Rules for placing ZIPs in INBOX_UPLOADS, automation behaviors, and verification steps post-ingest.【F:UPLOAD_CONTRACT.md†L1-L16】 |
+| PRODUCTION_CHECKLIST.md | Production Checklist (ZIP Ingest) | 2025-12-19 | Checklist for upload, automation, verification, and merge phases of ZIP ingest workflow.【F:PRODUCTION_CHECKLIST.md†L1-L17】 |

--- a/_exports/ECONOMY_CHAIN_POLICY.md
+++ b/_exports/ECONOMY_CHAIN_POLICY.md
@@ -1,0 +1,24 @@
+# Economy and Chain Policy Snapshot
+
+## Chain Jurisdiction Rules
+- Minting occurs on **DOGE inscriptions**; no random minting and numerology limits (333 / 589 / 999).【F:FASHION_DESIGN_SWARM.md†L38-L55】
+- Fees are restricted to "minimal chains" with payouts in **fiat or DOGE only**, emphasizing low-cost settlement.【F:FASHION_DESIGN_SWARM.md†L38-L58】
+
+## Asset Types per Chain
+- **DOGE**: Base NFTs and layered trait artifacts minted via inscriptions; burn-to-upgrade mechanics and Fibonacci rarity curves.【F:FASHION_DESIGN_SWARM.md†L38-L55】
+- Other chains (XRPL, XRP, Base, Solana, ERC-404/404): **No evidence found** in this repository snapshot.
+
+## Vault Model (Intent vs Custody)
+- A **Designer Vault** receives a **3% fee routed to a DCA engine**, suggesting semi-custodial treasury management tied to creator earnings.【F:FASHION_DESIGN_SWARM.md†L38-L58】
+- Wallet model is "Starbucks-style internal balance," implying account-based balances for users rather than self-custodied wallets; seed loss has real consequences by design.【F:FASHION_DESIGN_SWARM.md†L38-L58】
+
+## DCA Strategy Model
+- DCA is funded via the 3% vault fee; specific cadence/targets are unspecified, indicating an automated reinvestment sink fed by marketplace activity.【F:FASHION_DESIGN_SWARM.md†L38-L58】
+
+## Whitelist / Gating Model
+- Gating concepts are hinted via Trinity keyword lists (e.g., "gating", "vault", "permission"), but no concrete whitelist flows or enforcement rules are documented in accessible files.【F:scripts/vercel_zip_ingest.py†L18-L46】【F:TRINITY_INSTALL_CATALOG.md†L1-L31】
+- No explicit allowlist/whitelist policy is defined for minting or vault access in the current CRAB docs.
+
+## Other Keyword Mentions
+- **FEN / VRG33589 / 589**: Present only as repository names or numerology limits; no active chain policies beyond the 589 rarity numerology noted above.【F:STATE.md†L1-L33】【F:FASHION_DESIGN_SWARM.md†L45-L55】
+- **Vault** references outside the fashion brief are limited to Trinity keyword scans and do not describe custody mechanics.【F:scripts/vercel_zip_ingest.py†L18-L46】

--- a/_exports/MULTIVERSE_MIRRORS.md
+++ b/_exports/MULTIVERSE_MIRRORS.md
@@ -1,0 +1,10 @@
+# UI / Mirror Multiverse Inventory
+
+## Observed Mirrors
+- **University Bookstore Mirror** — Mentioned in Fashion Design Swarm as a commerce mirror for school-branded merch (digital + phygital SKUs). Status: **concept/brief only**; no UI code in this repo.【F:FASHION_DESIGN_SWARM.md†L60-L69】
+
+## Social / Market Mirrors Searched
+- X (Twitter), Facebook, Instagram, DexScreener, Coinbase, OpenSea, Magic Eden: **No references found** in accessible files or scripts.
+
+## Overall Status
+- The repository is documentation-centric; no front-end code or UI assets are present. Mirrors appear as conceptual placeholders only.

--- a/_exports/ONBOARDING_5GEN.md
+++ b/_exports/ONBOARDING_5GEN.md
@@ -1,0 +1,13 @@
+# Onboarding for 5 Generations
+
+## Source Signals
+- Fashion Design Swarm brief outlines onboarding Web2 fashion designers via progressive curriculum, dripONchain lab immersion, and built-in funnel steps.【F:FASHION_DESIGN_SWARM.md†L3-L69】 No other onboarding or accessibility rules found.
+
+## Tiered Summary
+- **Ultra-Basic (Entry/Funnel)** — Free design challenge → unlock prototype wearable; introduce wallet-as-balance model and no-random-mint ethos.【F:FASHION_DESIGN_SWARM.md†L60-L69】【F:FASHION_DESIGN_SWARM.md†L38-L58】
+- **Basic (Foundations / Year 1)** — Teach fashion fundamentals, color/material systems, and pattern logic; output non-tradable prototype garments minted via performance, not RNG.【F:FASHION_DESIGN_SWARM.md†L15-L33】
+- **Intermediate (Year 2 + Early Year 3)** — 3D garment construction, avatar fit systems, rigging/skin weights, and parametric code-driven design; outputs wearable NFTs with upgrade paths and trait unlocks via skill/burn events.【F:FASHION_DESIGN_SWARM.md†L20-L45】
+- **Advanced (Year 3–4 / Commerce)** — Dynamic NFTs with layer evolution (333/589/999), dripONchain economy rules (DOGE inscriptions, vault+DCA fees), university bookstore mirror, runway simulation, and designer vault royalties; supports paid drops and optional studio access.【F:FASHION_DESIGN_SWARM.md†L38-L69】
+
+## Accessibility / Neurodivergent Notes
+- No explicit neurodivergent-first or accessibility requirements documented in accessible files; future work should define sensory/load accommodations and alternative learning paths.

--- a/_exports/REPO_TREE.md
+++ b/_exports/REPO_TREE.md
@@ -1,0 +1,29 @@
+# Repo Tree Snapshot (depth 6)
+
+## Root
+- `/` — Workspace root holding CRAB governance docs plus numerous uploaded ZIP archives (mostly "3-DT" / Trinity-related packages awaiting ingest).
+- `/_exports/` — Generated reporting outputs (this run).
+- `/scripts/` — Python utilities for sorting/ingesting Vercel ZIP exports and regenerating audit docs.
+- `/VERCEL_HISTORY/` — Placeholder for processed ZIPs/manifests (`exports/` exists; other buckets created by automation).
+- `/.github/` — GitHub Actions workflows orchestrating ZIP sorting, ingest, and safety checks.
+
+## ZIP archives (root-level files)
+- `*3-dt*.zip`, `*3DT*.zip`, `akira-codex-*.zip`, `wired-chaos-hub-3-dt.zip`, `monorepo-layout-and-firewall.zip`, etc. — Uploaded source bundles; include 3DT/Trinity, Akira Codex, Discord bot builds, tax component, and other PATCH/prototype payloads.
+
+## scripts/
+- `scripts/vercel_zip_ingest.py` — Unpacks ZIPs from `INBOX_UPLOADS/`, scans for transcripts/Trinity keywords, updates manifests, and rewrites CRAB audit docs.
+- `scripts/vercel_zip_sorter.py` — Routes ZIPs into `VERCEL_HISTORY/{exports,3dt,builds,misc}` and updates a manifest with hashes/metadata.
+
+## VERCEL_HISTORY/
+- `VERCEL_HISTORY/exports/` — Houses ingest manifests and run summaries; empty of transcripts in current workspace snapshot.
+
+## .github/
+- `.github/workflows/vercel_zip_sorter.yml` — Auto-move uploaded ZIPs into `VERCEL_HISTORY` buckets; opens PRs with manifest updates.
+- `.github/workflows/vercel_zip_ingest.yml` — Runs ingest script on ZIP uploads; updates docs/manifests and opens PRs.
+- `.github/workflows/vercel_zip_safety.yml` — PR guard ensuring ZIPs stay inside `INBOX_UPLOADS/`.
+
+## Documentation files (root)
+- Governance/state: `KERNEL.md`, `STATE.md`, `PATCHES.md`, `RUNBOOK.md`.
+- Org/reporting: `README.md`, `ORG_SYNCHRONIZATION_REPORT.md`, `CRAB_LEGS_INDEX.md`, `TRINITY_*` audit files, `COPILOT_PROMPT.md`.
+- Operational: `UPLOAD_CONTRACT.md`, `PRODUCTION_CHECKLIST.md`.
+- Programs/briefs: `FASHION_DESIGN_SWARM.md`.

--- a/_exports/VALORITHIM.md
+++ b/_exports/VALORITHIM.md
@@ -1,0 +1,3 @@
+# Valorithim / Forensic Memory
+
+No references to "Valorithim," forensic memory systems, reputation/confidence scoring, or neurodivergent-focused cognition models were found in accessible files. Searches for memory/search/rank/reputation/neurodivergent keywords only returned Trinity transcript scan descriptions, not design specs.【F:TRINITY_INSTALL_CATALOG.md†L1-L31】【F:scripts/vercel_zip_ingest.py†L1-L120】 If such components exist, they are outside this snapshot or contained within unopened ZIP archives.

--- a/_exports/WIRED_CHAOS_CANONICAL_SUMMARY.md
+++ b/_exports/WIRED_CHAOS_CANONICAL_SUMMARY.md
@@ -1,0 +1,61 @@
+1. WHAT WIRED CHAOS IS
+Wired Chaos is framed as a multiverse alternate-reality game and creator economy that uses documentation, governance rules, and onboarding briefs to move participants from Web2 familiarity into structured Web3 experiences while tracking evidence through CRAB governance records.
+
+2. ECOSYSTEM COMPONENTS
+- CHAOS OS / CRAB Governance: Kernel, state, runbook, and patch queues that set rules for contributions and evidence.
+- WIRED CHAOS META: Fashion Design Swarm program outlining onboarding, curriculum, and economy behaviors.
+- FEN / VRG33589 / 589 numerology: Mentioned as identifiers and rarity caps within documents; no active modules observed.
+- Vaults and DCA Engine: Designer vault receiving a fee stream that powers automated reinvestment.
+- Agents and Automation: NEURO authority, maintainers, contributors, and GitHub Actions that sort and ingest ZIP evidence.
+- Mirrors: Conceptual storefront mirror (university bookstore) for digital and physical SKUs.
+- Trinity/3DT Audits: Placeholder audit catalogs awaiting transcripts to validate installations and gaps.
+- Documentation Stack: Repository maps, upload contracts, production checklists guiding operational flow.
+
+3. ECONOMY & CHAIN JURISDICTION
+- DOGE role: Primary chain for inscription-based NFTs with controlled supply using numerology limits and low-fee expectations.
+- XRPL role: No role documented in exports.
+- BASE role: No role documented in exports.
+- SOLANA role: No role documented in exports.
+- MONEY MAXI principle: Fees routed to minimal-cost chains with payouts in fiat or DOGE, prioritizing efficient settlement.
+
+4. VAULTS, NFTs & 404 DYNAMICS
+- Vaults are intent-based treasury balances rather than custody wallets, with a 3% fee siphoned to a DCA engine to reinvest creator earnings.
+- NFTs are DOGE inscriptions with layered trait artifacts, burn-to-upgrade mechanics, and rarity curves defined by Fibonacci-style caps; ERC-404 is mentioned only as a searched keyword with no supporting detail.
+- Users experience non-random minting tied to performance milestones, with internal balance models emphasizing the consequence of seed loss.
+
+5. VALORITHIM (FORENSIC SEARCH MEMORY)
+- No forensic memory or reputation system is described; searches found only references to transcript scanning mechanics.
+- Because no model is documented, nothing is tracked beyond ingest scripts looking for keywords, and no privacy constraints are specified.
+- Access difficulty or economy impacts from a Valorithim are absent in the exports.
+
+6. MULTIVERSE MIRRORS
+- Only a university bookstore mirror is noted as a commerce concept for digital and physical merchandise.
+- Mirrors are intended to bridge familiar retail contexts to on-chain drops, easing newcomers into Web3 commerce.
+- With no UI present, mirrors remain conceptual but align with the Web2-to-Web3 onboarding path.
+
+7. AGENTS, PATCHES & GOVERNANCE
+- NEURO acts as final authority on CRAB changes, with maintainers enforcing evidence and testing rules and contributors proposing patches.
+- Changes flow through a runbook-driven PR process, with patch queues and state tables capturing priorities and classifications.
+- Governance integrates CRAB/PATCH queues and automation workflows that ingest evidence and guard ZIP placement, aligning oversight with codified procedures.
+
+8. ONBOARDING FOR 5 GENERATIONS
+- Tiered onboarding moves from free design challenges to foundational garment skills, then 3D construction and parametric design, culminating in dynamic NFT commerce and studio access.
+- Accessibility guidance is not defined; neurodivergent-first practices are pending future specification.
+
+9. DEPLOYMENT & WORKSPACE ADAPTATION
+- New workspaces need Python 3.11+, INBOX_UPLOADS for ZIP intake, and the ability to run ingest/sorter scripts or GitHub Actions to refresh manifests and audit docs.
+- Non-developers can ignore build tooling; focus is on following upload contracts, production checklists, and governance evidence flows.
+
+10. ONE-PAGE TL;DR
+- Multiverse ARG economy guided by CRAB governance and fashion-focused META brief.
+- DOGE inscriptions with controlled supply anchor NFT activity; other chains not yet defined.
+- Vault fees power DCA reinvestment; internal balances emphasize custody caution.
+- No Valorithim or reputation engine present in exports.
+- Mirrors are conceptual storefronts to bridge Web2 commerce into on-chain drops.
+- Agents include NEURO authority, maintainers, and contributors, plus automation for ZIP ingest.
+- Patch and state queues track priorities and gaps, awaiting transcript evidence for Trinity audits.
+- Onboarding is progressive from challenges to advanced commerce, with explicit non-random minting ethos.
+- Deployment needs Python tooling and ZIP workflows; Vercel configs absent.
+- Evidence-first operations rely on manifests, audit docs, and PR-based governance.
+
+Gaps / TODOs: Whitelist and gating rules are undefined; Valorithim model is absent; XRPL/Base/Solana roles are not documented; UI/mirror implementations are missing; neurodivergent accessibility requirements remain to be written.


### PR DESCRIPTION
## Summary
- add a canonical WIRED CHAOS overview synthesized from existing export reports
- translate economy, governance, onboarding, and deployment notes into a single plain-language file for leadership use

## Testing
- not run (documentation-only changes)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6945c4809b808327ad427aeb511512fc)