### PR TITLE
Implement dual-rail token economy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+dist
+.env
+dev.db
+*.sqlite
+.prisma

--- a/config/tokenPacks.ts
+++ b/config/tokenPacks.ts
@@ -1,0 +1,46 @@
+export type TokenPack = {
+  id: string;
+  name: string;
+  tokens: number;
+  priceFiatCents: number;
+  fiatCurrency: string;
+  description?: string;
+  promoCodes?: string[];
+};
+
+export const DEFAULT_TOKEN = 'WC_TOKEN';
+
+export const tokenPacks: TokenPack[] = [
+  {
+    id: 'starter-500',
+    name: 'Starter',
+    tokens: 500,
+    priceFiatCents: 499,
+    fiatCurrency: 'USD',
+    description: 'Baseline pack for new explorers.'
+  },
+  {
+    id: 'booster-1200',
+    name: 'Booster',
+    tokens: 1200,
+    priceFiatCents: 999,
+    fiatCurrency: 'USD',
+    description: 'Bundle with bonus tokens for power users.'
+  },
+  {
+    id: 'creator-5000',
+    name: 'Creator',
+    tokens: 5000,
+    priceFiatCents: 3499,
+    fiatCurrency: 'USD',
+    description: 'High-volume rail for event drops and boosts.'
+  }
+];
+
+export function resolveTokenAmountFromPack(packId: string): { tokens: number; currency: string; priceCents: number } {
+  const pack = tokenPacks.find((p) => p.id === packId);
+  if (!pack) {
+    throw new Error('Invalid token pack');
+  }
+  return { tokens: pack.tokens, currency: pack.fiatCurrency, priceCents: pack.priceFiatCents };
+}

--- a/docs/economy/dual-rail-economy.md
+++ b/docs/economy/dual-rail-economy.md
@@ -1,0 +1,58 @@
+# WIRED CHAOS Dual-Rail Economy
+
+FIAT is ingress-only. All in-world spending uses WC Tokens. The token ledger is the source of truth for balances, entitlements, and disputes.
+
+## FIAT ingress flow
+1. Client calls `POST /api/checkout/create` with a token pack. Mobile deep-links to this web endpoint; no in-app purchases.
+2. Server resolves the pack price and tokens (never trusting client amounts) and creates a `PaymentIntent` plus a `CheckoutSession` record. The response contains the hosted checkout URL.
+3. Payment provider posts events to `POST /api/webhooks/payment-provider`. Signature verification gates processing.
+4. On `succeeded`, the webhook performs an idempotent credit: creates a `CREDIT_FIAT_PURCHASE` ledger entry, increments the `TokenAccount` balance, and marks the `PaymentIntent` as `SUCCEEDED`.
+5. On `failed` or `canceled`, only the statuses are updated. On `refunded`, the webhook writes a `DEBIT_REFUND_REVERSAL` entry and moves the `PaymentIntent` to `REFUNDED`.
+6. Every FIAT transaction maps 1:1 to a ledger credit entry via the payment `eventId` stored as the ledger `reasonCode`.
+
+## Token accounting model
+- `TokenAccount` (one per user per token type) holds the current balance. Default token type is `WC_TOKEN`.
+- `LedgerEntry` is append-only. Balances update only through paired transactions inside DB transactions to keep integrity.
+- Ledger entry types: `CREDIT_FIAT_PURCHASE`, `DEBIT_SPEND`, `CREDIT_REWARD`, `DEBIT_REFUND_REVERSAL`, `CREDIT_ADJUSTMENT`, `DEBIT_ADJUSTMENT`, `HOLD`, `RELEASE`.
+- Status values: `PENDING`, `SETTLED`, `FAILED`, `REVERSED`. Normal flows write `SETTLED`; refunds use `REVERSED`.
+- Idempotency: `(provider, providerIntentId, eventId/idempotencyKey)` must be unique. Webhook checks for an existing ledger entry using `reasonCode`.
+
+## Refund and dispute flow
+1. Refund is issued at the FIAT layer with the provider.
+2. Provider webhook sends `status=refunded` with the original `providerIntentId` and `eventId`.
+3. Server marks the `PaymentIntent` as `REFUNDED` and writes a `DEBIT_REFUND_REVERSAL` entry (negative tokens) against the account inside a transaction.
+4. Any downstream entitlement checks read from the ledger/balance; tokens removed here reflect the refund. Additional metadata can store dispute IDs for audits.
+
+## Security rules
+- Web checkout only; mobile links to the hosted checkout URL returned by `/api/checkout/create`.
+- Webhook signature verification uses `WEBHOOK_SECRET` and HMAC; failure returns HTTP 401.
+- Never trust client token or fiat amounts. Prices resolve from `config/tokenPacks.ts` or server-side conversion constants.
+- All balance mutations are transactional (Prisma `$transaction`), producing append-only ledger rows.
+- Unique constraints prevent double-crediting a provider intent. Ledger `reasonCode` uses the payment `eventId` for 1:1 auditability.
+- Rate-limit spending endpoints at the edge (middleware or gateway); payloads are schema-validated (Zod).
+- Identity, lore, and progression read balances only from the ledger; FIAT values never enter gameplay logic.
+
+## Patch billing interface
+Use `lib/economy/billing.ts` for all balance mutations:
+- `creditTokens(userId, amount, reasonCode, metadata?)` — credits balances and writes `CREDIT_FIAT_PURCHASE` entries.
+- `spendTokens(userId, amount, reasonCode, metadata?)` — debits balances with `DEBIT_SPEND` entries and checks sufficiency.
+- `getBalance(userId)` — returns current balance and recent ledger entries.
+- `createLedgerForRefund` — debits a reversed amount for refunds/disputes.
+
+## API surface
+- `POST /api/checkout/create` — start hosted checkout; returns checkout URL, `CheckoutSession` id, and `PaymentIntent` id.
+- `POST /api/webhooks/payment-provider` — provider event ingress with signature verification and idempotent credits/debits.
+- `POST /api/tokens/spend` — atomic spend with balance validation.
+- `GET /api/tokens/balance` — read balance + recent ledger.
+
+## Token store UI
+`public/token-store.html` lists packs, launches checkout, shows balances, and exposes a dev-only spend form to validate ledger writes.
+
+## Running locally
+```bash
+npm install
+export DATABASE_URL="file:./dev.db"
+npx prisma migrate dev --name init
+npm run dev
+```
+Visit `http://localhost:3000/token-store.html` to exercise the dual-rail flows.

--- a/lib/economy/billing.ts
+++ b/lib/economy/billing.ts
@@ -1,0 +1,121 @@
+import { prisma } from '../prisma.js';
+import { DEFAULT_TOKEN } from '../../config/tokenPacks.js';
+import { LedgerEntryType, LedgerStatus, Prisma, PrismaClient } from '@prisma/client';
+
+export type BillingMetadata = Record<string, unknown>;
+
+type DbClient = PrismaClient | Prisma.TransactionClient;
+
+async function ensureAccount(client: DbClient, userId: string, tokenType: string = DEFAULT_TOKEN) {
+  const existing = await client.tokenAccount.findFirst({ where: { userId, tokenType } });
+  if (existing) return existing;
+  return client.tokenAccount.create({ data: { userId, tokenType } });
+}
+
+export async function creditTokens(
+  userId: string,
+  amount: number,
+  reasonCode: string,
+  metadata?: BillingMetadata,
+  tokenType: string = DEFAULT_TOKEN,
+  currency = DEFAULT_TOKEN,
+  entryType: LedgerEntryType = LedgerEntryType.CREDIT_FIAT_PURCHASE
+) {
+  if (amount <= 0) throw new Error('Amount must be positive');
+  return prisma.$transaction(async (tx) => {
+    const account = await ensureAccount(tx, userId, tokenType);
+    const updatedAccount = await tx.tokenAccount.update({
+      where: { id: account.id },
+      data: { balance: { increment: amount } }
+    });
+    const entry = await tx.ledgerEntry.create({
+      data: {
+        userId,
+        accountId: updatedAccount.id,
+        type: entryType,
+        amount,
+        currency,
+        status: LedgerStatus.SETTLED,
+        reasonCode,
+        metadata: metadata ?? {}
+      }
+    });
+    return { balance: updatedAccount.balance, entry };
+  });
+}
+
+export async function spendTokens(
+  userId: string,
+  amount: number,
+  reasonCode: string,
+  metadata?: BillingMetadata,
+  tokenType: string = DEFAULT_TOKEN,
+  currency = DEFAULT_TOKEN,
+  entryType: LedgerEntryType = LedgerEntryType.DEBIT_SPEND
+) {
+  if (amount <= 0) throw new Error('Amount must be positive');
+  return prisma.$transaction(async (tx) => {
+    const account = await ensureAccount(tx, userId, tokenType);
+    if (account.balance < amount) {
+      throw new Error('Insufficient balance');
+    }
+    const updatedAccount = await tx.tokenAccount.update({
+      where: { id: account.id },
+      data: { balance: { decrement: amount } }
+    });
+    const entry = await tx.ledgerEntry.create({
+      data: {
+        userId,
+        accountId: updatedAccount.id,
+        type: entryType,
+        amount: -Math.abs(amount),
+        currency,
+        status: LedgerStatus.SETTLED,
+        reasonCode,
+        metadata: metadata ?? {}
+      }
+    });
+    return { balance: updatedAccount.balance, entry };
+  });
+}
+
+export async function getBalance(userId: string, tokenType: string = DEFAULT_TOKEN) {
+  const account = await ensureAccount(prisma, userId, tokenType);
+  const ledger = await prisma.ledgerEntry.findMany({
+    where: { accountId: account.id },
+    orderBy: { createdAt: 'desc' },
+    take: 10
+  });
+  return { balance: account.balance, ledger };
+}
+
+export async function createLedgerForRefund(
+  userId: string,
+  amount: number,
+  reasonCode: string,
+  metadata?: BillingMetadata,
+  tokenType: string = DEFAULT_TOKEN,
+  currency = DEFAULT_TOKEN
+) {
+  if (amount <= 0) throw new Error('Amount must be positive');
+  return prisma.$transaction(async (tx) => {
+    const account = await ensureAccount(tx, userId, tokenType);
+    const updatedAccount = await tx.tokenAccount.update({
+      where: { id: account.id },
+      data: { balance: { decrement: amount } }
+    });
+    const entry = await tx.ledgerEntry.create({
+      data: {
+        userId,
+        accountId: updatedAccount.id,
+        type: LedgerEntryType.DEBIT_REFUND_REVERSAL,
+        amount: -Math.abs(amount),
+        currency,
+        status: LedgerStatus.REVERSED,
+        reasonCode,
+        metadata: metadata ?? {}
+      }
+    });
+    return { balance: updatedAccount.balance, entry };
+  });
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({
+    errorFormat: 'pretty'
+  });
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "wired-chaos-economy",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "ts-node src/server.ts",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "build": "tsc",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.18.0",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "helmet": "^7.1.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.0.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.0",
+    "prisma": "^5.18.0"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,113 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        String          @id @default(cuid())
+  email     String          @unique
+  createdAt DateTime        @default(now())
+  accounts  TokenAccount[]
+  payments  PaymentIntent[]
+  sessions  CheckoutSession[]
+  ledger    LedgerEntry[]
+}
+
+model TokenAccount {
+  id        String        @id @default(cuid())
+  user      User          @relation(fields: [userId], references: [id])
+  userId    String
+  tokenType String        @default("WC_TOKEN")
+  balance   Int           @default(0)
+  ledger    LedgerEntry[]
+  createdAt DateTime      @default(now())
+
+  @@unique([userId, tokenType])
+}
+
+enum LedgerEntryType {
+  CREDIT_FIAT_PURCHASE
+  DEBIT_SPEND
+  CREDIT_REWARD
+  DEBIT_REFUND_REVERSAL
+  CREDIT_ADJUSTMENT
+  DEBIT_ADJUSTMENT
+  HOLD
+  RELEASE
+}
+
+enum LedgerStatus {
+  PENDING
+  SETTLED
+  FAILED
+  REVERSED
+}
+
+model LedgerEntry {
+  id          String          @id @default(cuid())
+  user        User            @relation(fields: [userId], references: [id])
+  userId      String
+  account     TokenAccount    @relation(fields: [accountId], references: [id])
+  accountId   String
+  type        LedgerEntryType
+  amount      Int
+  currency    String
+  status      LedgerStatus    @default(SETTLED)
+  reasonCode  String
+  metadata    Json?
+  createdAt   DateTime        @default(now())
+
+  @@index([userId])
+  @@index([accountId])
+}
+
+enum PaymentStatus {
+  CREATED
+  REQUIRES_ACTION
+  SUCCEEDED
+  FAILED
+  CANCELED
+  REFUNDED
+}
+
+model PaymentIntent {
+  id               String         @id @default(cuid())
+  user             User           @relation(fields: [userId], references: [id])
+  userId           String
+  provider         String
+  providerIntentId String
+  amountFiat       Int
+  fiatCurrency     String
+  status           PaymentStatus  @default(CREATED)
+  idempotencyKey   String
+  metadata         Json?
+  createdAt        DateTime       @default(now())
+  updatedAt        DateTime       @updatedAt
+  sessions         CheckoutSession[]
+
+  @@unique([provider, providerIntentId])
+  @@unique([provider, providerIntentId, idempotencyKey])
+}
+
+enum CheckoutStatus {
+  CREATED
+  REDIRECTED
+  COMPLETED
+  CANCELED
+}
+
+model CheckoutSession {
+  id             String          @id @default(cuid())
+  user           User            @relation(fields: [userId], references: [id])
+  userId         String
+  paymentIntent  PaymentIntent   @relation(fields: [paymentIntentId], references: [id])
+  paymentIntentId String
+  status         CheckoutStatus  @default(CREATED)
+  returnUrl      String
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+}

--- a/public/token-store.html
+++ b/public/token-store.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WIRED CHAOS Token Store</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 24px;
+        background: #0b0b0f;
+        color: #f3f3f5;
+      }
+      h1 {
+        color: #61dafb;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 16px;
+      }
+      .card {
+        border: 1px solid #1f1f2b;
+        padding: 16px;
+        border-radius: 8px;
+        background: #13131a;
+      }
+      button {
+        background: #61dafb;
+        border: none;
+        color: #0b0b0f;
+        padding: 10px 14px;
+        border-radius: 6px;
+        cursor: pointer;
+        font-weight: bold;
+      }
+      #ledger {
+        font-size: 13px;
+      }
+      .spend {
+        margin-top: 24px;
+        padding: 16px;
+        border: 1px dashed #2b2b37;
+        border-radius: 8px;
+      }
+      label {
+        display: block;
+        margin-bottom: 6px;
+      }
+      input, select {
+        padding: 8px;
+        width: 100%;
+        margin-bottom: 12px;
+        border-radius: 6px;
+        border: 1px solid #2b2b37;
+        background: #0f0f18;
+        color: #fff;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Token Store</h1>
+    <p>FIAT in → WC Tokens out. All in-app economy rides the token rail.</p>
+    <div>
+      <label for="userId">User ID</label>
+      <input id="userId" placeholder="user-123" value="demo-user" />
+    </div>
+    <section>
+      <h2>Token Packs</h2>
+      <div id="packs" class="grid"></div>
+    </section>
+
+    <section class="spend">
+      <h2>Spend Tokens (dev/admin demo)</h2>
+      <label for="spend-amount">Amount</label>
+      <input id="spend-amount" type="number" value="50" />
+      <label for="reason">Reason Code</label>
+      <input id="reason" value="dev_demo" />
+      <button id="spend">Spend</button>
+      <p id="spend-result"></p>
+    </section>
+
+    <section>
+      <h2>Balance</h2>
+      <p id="balance">Loading...</p>
+      <div id="ledger"></div>
+    </section>
+
+    <script>
+      async function fetchPacks() {
+        const res = await fetch('/api/token-packs');
+        const packs = await res.json();
+        const container = document.getElementById('packs');
+        container.innerHTML = '';
+        packs.forEach((pack) => {
+          const card = document.createElement('div');
+          card.className = 'card';
+          card.innerHTML = `
+            <h3>${pack.name}</h3>
+            <p>${pack.tokens} tokens</p>
+            <p>$${(pack.priceFiatCents / 100).toFixed(2)} ${pack.fiatCurrency}</p>
+            <p>${pack.description || ''}</p>
+            <button data-pack="${pack.id}">Buy Tokens</button>
+          `;
+          card.querySelector('button').addEventListener('click', () => startCheckout(pack.id));
+          container.appendChild(card);
+        });
+      }
+
+      async function startCheckout(packId) {
+        const userId = (document.getElementById('userId')).value;
+        const res = await fetch('/api/checkout/create', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tokenPackId: packId, returnUrl: window.location.href, userId })
+        });
+        const data = await res.json();
+        if (data.checkoutUrl) {
+          window.alert('Redirecting to checkout: ' + data.checkoutUrl);
+        } else {
+          window.alert('Checkout failed: ' + data.error);
+        }
+      }
+
+      async function loadBalance() {
+        const userId = (document.getElementById('userId')).value;
+        const res = await fetch(`/api/tokens/balance?userId=${encodeURIComponent(userId)}`);
+        const data = await res.json();
+        document.getElementById('balance').innerText = `Balance: ${data.balance} ${'WC_TOKEN'}`;
+        const ledgerDiv = document.getElementById('ledger');
+        ledgerDiv.innerHTML = '<h3>Recent ledger</h3>' +
+          data.ledger
+            .map((entry) => `<div>${entry.type} — ${entry.amount} (${entry.reasonCode})</div>`)
+            .join('');
+      }
+
+      async function spend() {
+        const userId = (document.getElementById('userId')).value;
+        const amount = Number((document.getElementById('spend-amount')).value);
+        const reason = (document.getElementById('reason')).value;
+        const res = await fetch('/api/tokens/spend', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userId, amount, reasonCode: reason })
+        });
+        const data = await res.json();
+        document.getElementById('spend-result').innerText = data.error
+          ? data.error
+          : `Spent. New balance: ${data.balance}`;
+        loadBalance();
+      }
+
+      document.getElementById('spend').addEventListener('click', spend);
+      document.getElementById('userId').addEventListener('change', loadBalance);
+      fetchPacks().then(loadBalance);
+    </script>
+  </body>
+</html>

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,208 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import crypto from 'crypto';
+import { z } from 'zod';
+import { prisma } from '../lib/prisma.js';
+import { DEFAULT_TOKEN, resolveTokenAmountFromPack, tokenPacks } from '../config/tokenPacks.js';
+import { creditTokens, spendTokens, getBalance, createLedgerForRefund } from '../lib/economy/billing.js';
+import { CheckoutStatus, PaymentStatus } from '@prisma/client';
+
+const app = express();
+app.use(cors());
+app.use(helmet());
+app.use(express.json());
+
+const RATE_CENTS_PER_TOKEN = 1; // fallback when explicit pack not provided
+const DEFAULT_PROVIDER = 'mock-provider';
+
+function computeFiatForTokens(tokens: number) {
+  return tokens * RATE_CENTS_PER_TOKEN;
+}
+
+function validateSignature(body: string, signature: string | undefined, secret: string | undefined) {
+  if (!secret) return true; // allow open validation in dev
+  if (!signature) return false;
+  const digest = crypto.createHmac('sha256', secret).update(body).digest('hex');
+  return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(digest));
+}
+
+app.post('/api/checkout/create', async (req, res) => {
+  try {
+    const schema = z.object({
+      tokenPackId: z.string().optional(),
+      tokensAmount: z.number().int().positive().optional(),
+      returnUrl: z.string().url(),
+      userId: z.string().min(1)
+    });
+    const parsed = schema.parse(req.body);
+    if (!parsed.tokenPackId && !parsed.tokensAmount) {
+      return res.status(400).json({ error: 'tokenPackId or tokensAmount is required' });
+    }
+
+    const idempotencyKey = (req.headers['idempotency-key'] as string) || crypto.randomUUID();
+
+    let tokens = parsed.tokensAmount ?? 0;
+    let fiatCurrency = 'USD';
+    let priceCents = 0;
+
+    if (parsed.tokenPackId) {
+      const pack = resolveTokenAmountFromPack(parsed.tokenPackId);
+      tokens = pack.tokens;
+      fiatCurrency = pack.currency;
+      priceCents = pack.priceCents;
+    } else if (parsed.tokensAmount) {
+      tokens = parsed.tokensAmount;
+      priceCents = computeFiatForTokens(tokens);
+    }
+
+    const paymentIntent = await prisma.paymentIntent.create({
+      data: {
+        userId: parsed.userId,
+        provider: DEFAULT_PROVIDER,
+        providerIntentId: crypto.randomUUID(),
+        amountFiat: priceCents,
+        fiatCurrency,
+        idempotencyKey,
+        status: PaymentStatus.CREATED,
+        metadata: { tokenPackId: parsed.tokenPackId, tokensPurchased: tokens }
+      }
+    });
+
+    const checkoutSession = await prisma.checkoutSession.create({
+      data: {
+        userId: parsed.userId,
+        paymentIntentId: paymentIntent.id,
+        status: CheckoutStatus.CREATED,
+        returnUrl: parsed.returnUrl
+      }
+    });
+
+    const checkoutUrl = `https://payments.example.com/checkout/${checkoutSession.id}`;
+    res.json({ checkoutUrl, checkoutSessionId: checkoutSession.id, paymentIntentId: paymentIntent.id });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ error: 'Failed to create checkout', detail: (err as Error).message });
+  }
+});
+
+app.post('/api/webhooks/payment-provider', express.text({ type: '*/*' }), async (req, res) => {
+  const signature = req.headers['x-webhook-signature'] as string | undefined;
+  const secret = process.env.WEBHOOK_SECRET;
+  const verified = validateSignature(req.body, signature, secret);
+  if (!verified) {
+    return res.status(401).json({ error: 'invalid signature' });
+  }
+
+  try {
+    const parsedBody = JSON.parse(req.body);
+    const schema = z.object({
+      provider: z.string(),
+      providerIntentId: z.string(),
+      eventId: z.string(),
+      status: z.enum(['succeeded', 'failed', 'canceled', 'refunded']),
+      tokensPurchased: z.number().int().nonnegative().optional(),
+      userId: z.string().min(1),
+      reasonCode: z.string().default('fiat_purchase'),
+      metadata: z.record(z.any()).optional()
+    });
+    const event = schema.parse(parsedBody);
+
+    const paymentIntent = await prisma.paymentIntent.findUnique({
+      where: { provider_providerIntentId: { provider: event.provider, providerIntentId: event.providerIntentId } }
+    });
+    if (!paymentIntent) {
+      return res.status(404).json({ error: 'PaymentIntent not found' });
+    }
+
+    const existingLedger = await prisma.ledgerEntry.findFirst({
+      where: { account: { userId: paymentIntent.userId }, reasonCode: event.eventId }
+    });
+    if (existingLedger) {
+      return res.json({ status: 'already-processed' });
+    }
+
+    if (event.status === 'succeeded') {
+      await prisma.$transaction(async (tx) => {
+        await tx.paymentIntent.update({
+          where: { id: paymentIntent.id },
+          data: { status: PaymentStatus.SUCCEEDED }
+        });
+        const tokens = event.tokensPurchased ?? (paymentIntent.metadata as any)?.tokensPurchased ?? 0;
+        const { entry } = await creditTokens(paymentIntent.userId, tokens, event.eventId, {
+          providerIntentId: paymentIntent.providerIntentId,
+          provider: paymentIntent.provider,
+          eventId: event.eventId,
+          metadata: event.metadata
+        });
+        return entry;
+      });
+    } else if (event.status === 'failed') {
+      await prisma.paymentIntent.update({
+        where: { id: paymentIntent.id },
+        data: { status: PaymentStatus.FAILED }
+      });
+    } else if (event.status === 'canceled') {
+      await prisma.paymentIntent.update({
+        where: { id: paymentIntent.id },
+        data: { status: PaymentStatus.CANCELED }
+      });
+    } else if (event.status === 'refunded') {
+      await prisma.$transaction(async (tx) => {
+        await tx.paymentIntent.update({
+          where: { id: paymentIntent.id },
+          data: { status: PaymentStatus.REFUNDED }
+        });
+        const tokens = event.tokensPurchased ?? (paymentIntent.metadata as any)?.tokensPurchased ?? 0;
+        await createLedgerForRefund(paymentIntent.userId, tokens, event.eventId, {
+          providerIntentId: paymentIntent.providerIntentId,
+          provider: paymentIntent.provider,
+          eventId: event.eventId,
+          metadata: event.metadata
+        });
+      });
+    }
+
+    res.json({ status: 'ok' });
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ error: 'webhook processing failed', detail: (err as Error).message });
+  }
+});
+
+app.post('/api/tokens/spend', async (req, res) => {
+  try {
+    const schema = z.object({
+      userId: z.string().min(1),
+      amount: z.number().int().positive(),
+      reasonCode: z.string(),
+      metadata: z.record(z.any()).optional()
+    });
+    const body = schema.parse(req.body);
+
+    const result = await spendTokens(body.userId, body.amount, body.reasonCode, body.metadata);
+    res.json({ balance: result.balance, entry: result.entry });
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+app.get('/api/tokens/balance', async (req, res) => {
+  const userId = req.query.userId as string;
+  if (!userId) {
+    return res.status(400).json({ error: 'userId is required' });
+  }
+  const result = await getBalance(userId);
+  res.json(result);
+});
+
+app.get('/api/token-packs', (_req, res) => {
+  res.json(tokenPacks);
+});
+
+app.use(express.static('public'));
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Dual-rail economy server ready on port ${PORT}`);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*", "lib/**/*", "config/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add Prisma schema and token pack configuration for the dual-rail economy ledger, payment intents, and checkout sessions
- implement Express API surface for checkout creation, webhook-driven token credits/refunds, balance reads, and token spending plus billing helper library
- document the dual-rail flows and ship a static token store page for buying/spending tokens

## Testing
- npm install --ignore-scripts *(fails: registry 403 restriction)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6945f8ee576883279699d9c74f5440df)