### PR TITLE
Add 3DT registry documentation and governance rules

### DIFF
--- a/GOVERNANCE/CONSUMER_3DT_CONTRACT.md
+++ b/GOVERNANCE/CONSUMER_3DT_CONTRACT.md
@@ -1,0 +1,19 @@
+# 3DT Consumer Contract
+
+Any registry entry with `consumer_3dt=true` is a Trinity/3DT consumer. These consumers:
+- **Do not own infrastructure.** Execution, scaling, and hosting stay under Wired Chaos control.
+- **Do not control the runtime.** Scheduling, orchestration, and lifecycle management are enforced by WIRED CHAOS.
+- **Inherit WIRED CHAOS execution, security, and lifecycle.** All security controls, audit trails, and deprecation policies apply automatically.
+
+## Allowed Contributions
+3DT consumers may supply:
+- **Inputs:** Structured data, interaction parameters, and telemetry the runtime accepts.
+- **Artifacts:** Files or proofs referenced in `PATCH_REGISTRY.json` for unlocks, validation, or continuity.
+- **Content descriptors:** Narrative or media descriptors that the runtime can surface while retaining CODEX authority over truth.
+
+## Non-Negotiable Boundaries
+3DT consumers may **never** override:
+- **Execution order:** Timelines and routing are enforced by CODEX registry truth and WIRED CHAOS runtime.
+- **Permissions:** Access rules, gating, and unlock conditions are set in the registry and enforced by runtime guardians.
+- **Registry truth:** IDs, relationships, and statuses in `PATCH_REGISTRY.json` are authoritative.
+- **Timeline authority:** Timeline composition, allowed skips, and linkage logic remain under CODEX and WIRED CHAOS governance.

--- a/GOVERNANCE/TRINITY_ELEVATOR_RULES.md
+++ b/GOVERNANCE/TRINITY_ELEVATOR_RULES.md
@@ -1,0 +1,27 @@
+# Trinity Elevator Routing Rules
+
+These rules describe how Trinity rooms link, unlock, and respect gating across the WIRED CHAOS multiverse. They are UI-agnostic and assume the PATCH registry is the single source of truth.
+
+## Link Resolution
+- `PATCH_REGISTRY.links` enumerates valid outbound routes from a room. Frontends should only present or traverse links listed in the registry.
+- Hubs may have fan-out links; timelines can list patches or other hubs to express allowed progression.
+- Routes are directional as listed. Bidirectional travel must be explicitly declared on both sides.
+
+## Timeline Skipping
+- Skipping a timeline segment is permitted only when the registry gate `allow_skip_if` is satisfied.
+- Skip rules must be deterministic strings resolved by the WIRED CHAOS runtime (e.g., `artifact:<id>`, `manual-override:<role>`).
+- If no skip rule is met, traversal must follow registry order or stay on the current node.
+
+## Locked Room Behavior
+- **Locked + visible:** Room is listed but cannot be entered until gates are satisfied.
+- **Locked + invisible:** Room is hidden until any gate dependency changes state (artifact, NFT, clue, or override) and visibility is recalculated.
+- Visibility must be recalculated by the runtime after each state change (artifact acquisition, NFT verification, clue resolution, or override).
+
+## Gate Priority
+When evaluating access, apply the highest satisfied condition first:
+1. Artifact possession
+2. NFT verification
+3. Clue resolution
+4. Manual override
+
+A higher-priority satisfied condition unlocks traversal regardless of lower-priority states. If multiple conditions are unsatisfied, traversal remains blocked until the next priority threshold is met.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,6 @@ Uploads are drop-only: place `.zip` files in `INBOX_UPLOADS/` via **Add file →
 
 - [UPLOAD_CONTRACT.md](UPLOAD_CONTRACT.md) — plain-language rules and what happens automatically.
 - [PRODUCTION_CHECKLIST.md](PRODUCTION_CHECKLIST.md) — step-by-step checks for upload, automation, verification, and merge.
+
+## 3DT Multiverse Overview
+CODEX operates as the truth layer holding manifests, contracts, and state. WIRED CHAOS is the execution layer enforcing runtime, security, and lifecycle. 3DT is the experiential layer that renders traversal for participants once conditions are satisfied. Users traverse patches non-linearly, hopping across hubs and timelines after clearing required gates, reflecting a multiverse of routes instead of a single linear application.

--- a/REGISTRY/PATCH_REGISTRY.json
+++ b/REGISTRY/PATCH_REGISTRY.json
@@ -1,0 +1,162 @@
+[
+  {
+    "id": "wired-chaos-hub-3dt",
+    "name": "Wired Chaos Hub",
+    "type": "HUB",
+    "consumer_3dt": true,
+    "description": "Anchor hub for cross-timeline routing and runtime synchronization across the multiverse.",
+    "artifacts": ["hub-schematic-v1", "runtime-handshake-proof"],
+    "timelines": ["trinity-prime-timeline"],
+    "gates": {
+      "requires_nft": null,
+      "requires_artifact": "hub-schematic-v1",
+      "requires_clue": null,
+      "allow_skip_if": ["manual-override:core-admin"]
+    },
+    "links": ["akira-codex-engine-3dt", "fen-trifecta-3dt", "vault33-layer-3dt"],
+    "status_defaults": {
+      "locked": false,
+      "visible": true
+    }
+  },
+  {
+    "id": "akira-codex-engine-3dt",
+    "name": "AKIRA Codex Engine",
+    "type": "PATCH",
+    "consumer_3dt": true,
+    "description": "Execution-grade patch exposing AKIRA runtimes for Trinity test harnessing.",
+    "artifacts": ["akira-engine-build", "akira-diagnostics-report"],
+    "timelines": ["trinity-prime-timeline"],
+    "gates": {
+      "requires_nft": "akira-access-pass",
+      "requires_artifact": null,
+      "requires_clue": null,
+      "allow_skip_if": ["artifact:akira-diagnostics-report"]
+    },
+    "links": ["fen-trifecta-3dt", "vault33-layer-3dt"],
+    "status_defaults": {
+      "locked": true,
+      "visible": true
+    }
+  },
+  {
+    "id": "fen-trifecta-3dt",
+    "name": "FEN Trifecta",
+    "type": "PATCH",
+    "consumer_3dt": true,
+    "description": "Tri-lane traversal proving ground tying FEN data, navigation, and signal-handling.",
+    "artifacts": ["fen-map-fragment", "fen-audio-token"],
+    "timelines": ["trinity-prime-timeline", "afterhours-thread"],
+    "gates": {
+      "requires_nft": null,
+      "requires_artifact": "fen-map-fragment",
+      "requires_clue": "fen-audio-cipher",
+      "allow_skip_if": ["artifact:fen-audio-token"]
+    },
+    "links": ["vault33-layer-3dt", "789-afterhours-3dt"],
+    "status_defaults": {
+      "locked": true,
+      "visible": false
+    }
+  },
+  {
+    "id": "vault33-layer-3dt",
+    "name": "Vault33 Layer",
+    "type": "PATCH",
+    "consumer_3dt": true,
+    "description": "Containment chamber for state snapshots, secure storage proofs, and Trinity elevator anchoring.",
+    "artifacts": ["vault33-snapshot", "elevator-handshake"],
+    "timelines": ["trinity-prime-timeline"],
+    "gates": {
+      "requires_nft": "vault33-keycard",
+      "requires_artifact": "vault33-snapshot",
+      "requires_clue": null,
+      "allow_skip_if": ["manual-override:security-officer"]
+    },
+    "links": ["fen-trifecta-3dt", "wired-chaos-hub-3dt"],
+    "status_defaults": {
+      "locked": true,
+      "visible": true
+    }
+  },
+  {
+    "id": "789-afterhours-3dt",
+    "name": "789 Afterhours",
+    "type": "PATCH",
+    "consumer_3dt": true,
+    "description": "Late-cycle exploration strand carrying nightlife telemetry and social puzzles.",
+    "artifacts": ["afterhours-ticket", "signal-polaroid"],
+    "timelines": ["afterhours-thread"],
+    "gates": {
+      "requires_nft": null,
+      "requires_artifact": "afterhours-ticket",
+      "requires_clue": "afterhours-frequency",
+      "allow_skip_if": []
+    },
+    "links": ["fen-trifecta-3dt", "wired-chaos-hub-3dt"],
+    "status_defaults": {
+      "locked": true,
+      "visible": true
+    }
+  },
+  {
+    "id": "cipher-lab-alpha",
+    "name": "Cipher Lab Alpha",
+    "type": "PATCH",
+    "consumer_3dt": false,
+    "description": "Non-3DT research patch focused on offline cryptography drills and clue authoring.",
+    "artifacts": ["cipher-keyring", "lab-notes-v1"],
+    "timelines": ["trinity-prime-timeline"],
+    "gates": {
+      "requires_nft": null,
+      "requires_artifact": null,
+      "requires_clue": null,
+      "allow_skip_if": []
+    },
+    "links": ["wired-chaos-hub-3dt"],
+    "status_defaults": {
+      "locked": false,
+      "visible": true
+    }
+  },
+  {
+    "id": "trinity-prime-timeline",
+    "name": "Trinity Prime Timeline",
+    "type": "TIMELINE",
+    "consumer_3dt": false,
+    "description": "Primary canonical sequence linking core patches and governance checkpoints.",
+    "artifacts": [],
+    "timelines": [],
+    "gates": {
+      "requires_nft": null,
+      "requires_artifact": null,
+      "requires_clue": null,
+      "allow_skip_if": []
+    },
+    "links": ["wired-chaos-hub-3dt", "akira-codex-engine-3dt", "vault33-layer-3dt", "cipher-lab-alpha"],
+    "status_defaults": {
+      "locked": false,
+      "visible": true
+    }
+  },
+  {
+    "id": "afterhours-thread",
+    "name": "Afterhours Thread",
+    "type": "TIMELINE",
+    "consumer_3dt": false,
+    "description": "Parallel thread aggregating nightlife and social discovery patches for late-session traversal.",
+    "artifacts": [],
+    "timelines": [],
+    "gates": {
+      "requires_nft": null,
+      "requires_artifact": null,
+      "requires_clue": null,
+      "allow_skip_if": []
+    },
+    "links": ["fen-trifecta-3dt", "789-afterhours-3dt", "wired-chaos-hub-3dt"],
+    "status_defaults": {
+      "locked": false,
+      "visible": true
+    }
+  }
+]

--- a/RUNTIME/REGISTRY_ADAPTER.md
+++ b/RUNTIME/REGISTRY_ADAPTER.md
@@ -1,0 +1,41 @@
+# Registry Adapter Contract
+
+This contract defines how `REGISTRY/PATCH_REGISTRY.json` is consumed by WIRED CHAOS runtime services and 3DT frontends while allowing the data source to be swapped without refactors.
+
+## Purpose
+- **WIRED CHAOS runtime:** Loads the registry to enforce gates, route traversal, and synchronize status defaults across timelines.
+- **3DT frontends:** Render room state and available routes based on the same authoritative registry without embedding business logic.
+
+## Required Fields
+Each registry entry **must** include:
+- `id` (string, kebab-case, globally unique)
+- `name` (string)
+- `type` (`"PATCH" | "TIMELINE" | "HUB"`)
+- `consumer_3dt` (boolean)
+- `description` (string)
+- `artifacts` (array of strings; empty allowed)
+- `timelines` (array of timeline ids the entry belongs to; empty for timeline entries)
+- `gates` (object)
+  - `requires_nft` (string|null)
+  - `requires_artifact` (string|null)
+  - `requires_clue` (string|null)
+  - `allow_skip_if` (array of rule strings)
+- `links` (array of ids this entry can route to)
+- `status_defaults` (object)
+  - `locked` (boolean)
+  - `visible` (boolean)
+
+## Optional / Interpreted Fields
+- Empty arrays or `null` values are valid and indicate no requirement for that field.
+- Runtime may extend entries with computed state (e.g., `resolved_locked`) but must not mutate the persisted registry schema.
+
+## Adapter Responsibilities
+- Validate schema on load and reject entries missing required fields.
+- Normalize IDs and links to ensure referential integrity across patches, timelines, and hubs.
+- Expose a stable access layer (e.g., `getNode(id)`, `listLinks(id)`, `canSkip(id, state)`) that frontends and services can call without knowing storage details.
+- Preserve read-only behavior for consumers: mutation APIs must be runtime-internal and may not be surfaced to frontends.
+
+## Forward-Compatibility Guarantees
+- New fields will be additive; existing fields retain type and meaning.
+- Unknown fields must be ignored by consumers but preserved through load/save cycles.
+- Versioning is controlled by CODEX. Runtimes and UIs must tolerate new optional fields without code changes by relying on the required field contract above.


### PR DESCRIPTION
## Summary
- add authoritative PATCH_REGISTRY entries for Trinity hubs, patches, and timelines
- define governance contracts for 3DT consumers and Trinity elevator routing
- document registry adapter expectations and update README with multiverse overview

## Testing
- not run (documentation and data-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6945f9bc15ec8327a11ef7143fd06669)