### PR TITLE
Harden 3DT pipeline inputs and worker job claiming

### DIFF
--- a/.github/workflows/wired_chaos_3dt_pipeline.yml
+++ b/.github/workflows/wired_chaos_3dt_pipeline.yml
@@ -37,17 +37,24 @@ jobs:
           python-version: "3.11"
 
       - name: Register intake job
+        env:
+          INTAKE_ID: ${{ inputs.intake_id }}
+          CONSUMER: ${{ inputs.consumer }}
+          VERSION: ${{ inputs.version }}
+          NOTES: ${{ inputs.notes }}
         run: |
           python scripts/wired_chaos_3dt_pipeline.py \
-            --intake-id "${{ inputs.intake_id }}" \
-            --consumer "${{ inputs.consumer }}" \
-            --version "${{ inputs.version }}" \
-            --notes "${{ inputs.notes }}"
+            --intake-id "$INTAKE_ID" \
+            --consumer "$CONSUMER" \
+            --version "$VERSION" \
+            --notes "$NOTES"
 
       - name: Capture job version
         id: summary
+        env:
+          INTAKE_ID: ${{ inputs.intake_id }}
         run: |
-          VERSION=$(jq -r ".jobs[\"${{ inputs.intake_id }}\"].last_version" WIRED_CHAOS_3DT/_JOBS_MANIFEST.json)
+          VERSION=$(jq -r ".jobs[\"$INTAKE_ID\"].last_version" WIRED_CHAOS_3DT/_JOBS_MANIFEST.json)
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Detect changes
@@ -75,5 +82,8 @@ jobs:
             - Metadata recorded; rendering deliberately not executed
 
       - name: Log summary
+        env:
+          INTAKE_ID: ${{ inputs.intake_id }}
+          CONSUMER: ${{ inputs.consumer }}
         run: |
-          echo "Registered ${{ inputs.intake_id }} for ${{ inputs.consumer }} at version ${{ steps.summary.outputs.version }} (placeholders only)."
+          echo "Registered $INTAKE_ID for $CONSUMER at version ${{ steps.summary.outputs.version }} (placeholders only)."

--- a/.github/workflows/wired_chaos_3dt_worker.yml
+++ b/.github/workflows/wired_chaos_3dt_worker.yml
@@ -20,9 +20,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Wired Chaos 3DT worker
+        env:
+          WATCH: ${{ github.event.inputs.watch }}
+          POLL_SECONDS: ${{ github.event.inputs.poll_seconds }}
         run: |
           python -m pip install --upgrade pip
           python scripts/wired_chaos_3dt_worker.py \
-            $( [ "${{ github.event.inputs.watch }}" = "true" ] && echo --watch ) \
-            --poll-seconds "${{ github.event.inputs.poll_seconds }}" \
+            $( [ "$WATCH" = "true" ] && echo --watch ) \
+            --poll-seconds "$POLL_SECONDS" \
             --verbose

--- a/scripts/wired_chaos_3dt_pipeline.py
+++ b/scripts/wired_chaos_3dt_pipeline.py
@@ -64,6 +64,23 @@ def _ensure_base_dirs() -> None:
         path.mkdir(parents=True, exist_ok=True)
 
 
+def _validate_segment(value: str, field: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        raise ValueError(f"{field} cannot be empty")
+
+    # Limit to safe folder name characters and forbid traversal tokens.
+    if "/" in candidate or "\\" in candidate or ".." in candidate:
+        raise ValueError(f"{field} contains invalid path separators or traversal sequences")
+
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", candidate):
+        raise ValueError(
+            f"{field} must use alphanumeric characters, dots, underscores, or hyphens only"
+        )
+
+    return candidate
+
+
 def _prepare_job_dirs(job_id: str, version: str) -> Path:
     job_root = JOBS_DIR / job_id
     version_dir = job_root / "versions" / version
@@ -129,21 +146,26 @@ def register_job(intake_id: str, consumer: str, requested_version: Optional[str]
     if not normalized_consumer.lower().endswith("-3dt"):
         raise ValueError("consumer must end with '-3DT' to be treated as an execution consumer")
 
+    safe_intake_id = _validate_segment(intake_id, "intake_id")
+    safe_requested_version = None
+    if requested_version:
+        safe_requested_version = _validate_segment(requested_version, "requested version")
+
     _ensure_base_dirs()
-    intake_path = INTAKE_DIR / intake_id
+    intake_path = INTAKE_DIR / safe_intake_id
     intake_path.mkdir(parents=True, exist_ok=True)
 
     existing_versions: List[str] = []
-    versions_dir = JOBS_DIR / intake_id / "versions"
+    versions_dir = JOBS_DIR / safe_intake_id / "versions"
     if versions_dir.exists():
         existing_versions = [p.name for p in versions_dir.iterdir() if p.is_dir()]
 
-    version = _next_version(existing_versions, requested_version)
+    version = _validate_segment(_next_version(existing_versions, safe_requested_version), "version")
     timestamp = dt.datetime.utcnow().isoformat(timespec="seconds") + "Z"
 
-    version_dir = _prepare_job_dirs(intake_id, version)
+    version_dir = _prepare_job_dirs(safe_intake_id, version)
     metadata = {
-        "job_id": intake_id,
+        "job_id": safe_intake_id,
         "consumer": normalized_consumer,
         "version": version,
         "timestamp": timestamp,
@@ -155,7 +177,7 @@ def register_job(intake_id: str, consumer: str, requested_version: Optional[str]
         "notes": notes,
     }
     _write_version_metadata(version_dir, metadata)
-    _update_manifest(intake_id, version, normalized_consumer, timestamp, notes, status="queued")
+    _update_manifest(safe_intake_id, version, normalized_consumer, timestamp, notes, status="queued")
     return version
 
 

--- a/scripts/wired_chaos_3dt_worker.py
+++ b/scripts/wired_chaos_3dt_worker.py
@@ -80,15 +80,28 @@ def _update_manifest_status(job_id: str, version: str, status: str, timestamp: s
 
 
 def _claim_job(metadata_path: Path) -> Optional[Dict]:
-    metadata = _load_json(metadata_path)
-    if metadata.get("status") != STATUS_QUEUED:
+    lock_path = metadata_path.with_suffix(".lock")
+    try:
+        lock_path.open("x").close()
+    except FileExistsError:
+        # Another worker is already claiming or processing this job.
         return None
 
-    metadata["status"] = STATUS_RUNNING
-    metadata["started_at"] = dt.datetime.utcnow().isoformat(timespec="seconds") + "Z"
-    _save_json(metadata_path, metadata)
-    _update_manifest_status(metadata["job_id"], metadata["version"], STATUS_RUNNING, metadata["started_at"])
-    return metadata
+    try:
+        metadata = _load_json(metadata_path)
+        if metadata.get("status") != STATUS_QUEUED:
+            return None
+
+        metadata["status"] = STATUS_RUNNING
+        metadata["started_at"] = dt.datetime.utcnow().isoformat(timespec="seconds") + "Z"
+        _save_json(metadata_path, metadata)
+        _update_manifest_status(
+            metadata["job_id"], metadata["version"], STATUS_RUNNING, metadata["started_at"]
+        )
+        return metadata
+    finally:
+        if lock_path.exists():
+            lock_path.unlink()
 
 
 def _complete_job(metadata_path: Path, metadata: Dict) -> None:


### PR DESCRIPTION
## Summary
- add atomic lock-based job claiming to prevent concurrent worker execution
- validate intake and version segments to block path traversal in the pipeline
- run workflow inputs through environment variables to avoid shell injection risks

## Testing
- python -m compileall scripts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6946d4e37b608327b121829dafbb8926)