### PR TITLE
Add schemas for worlds, patches, and timeline events

### DIFF
--- a/src/schemas/entities.ts
+++ b/src/schemas/entities.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const WorldSchema = z.object({
+  id: z.string().regex(/^[a-z0-9-]+$/),
+  name: z.string(),
+  tokenMatch: z.string(), // Membership rule
+  status: z.enum(['active', 'drift', 'archived']).default('active'),
+});
+
+export const PatchSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  version: z.string(),
+  canonical: z.boolean().default(true),
+  worldId: z.string().optional(),
+});
+
+export const TimelineEventSchema = z.object({
+  timestamp: z.string().datetime(),
+  type: z.string(),
+  description: z.string(),
+  metadata: z.record(z.any()).optional(),
+});
+
+export type World = z.infer<typeof WorldSchema>;
+export type Patch = z.infer<typeof PatchSchema>;
+export type TimelineEvent = z.infer<typeof TimelineEventSchema>;


### PR DESCRIPTION
## Summary
- add Zod schemas for worlds, patches, and timeline events
- export inferred TypeScript types for reuse across the project

## Testing
- npm run build *(fails: existing type errors in billing and server related to Prisma enum types and missing cors types)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69471bf546f08327b770fa3e01247ab9)