### PR TITLE
Add generic path engine with world path definitions

### DIFF
--- a/src/lib/pathEngine/index.ts
+++ b/src/lib/pathEngine/index.ts
@@ -1,0 +1,159 @@
+import { CreateTimelineEvent } from '../../types/registry.js';
+import {
+  PathDefinition,
+  PathEngine as PathEngineType,
+  PathEngineOptions,
+  PathNode,
+  TimelinePublisher,
+  WorldId
+} from '../../types/pathEngine.js';
+import { pathDefinitions } from './paths.js';
+
+const DEFAULT_ENTER_EVENT = 'PATH_NODE_ENTERED';
+const DEFAULT_COMPLETE_EVENT = 'PATH_NODE_COMPLETED';
+
+function hasRequiredPatches(node: PathNode, patches: Set<string>): boolean {
+  const required = node.gate?.required ?? [];
+  return required.every(req => patches.has(req));
+}
+
+function isBlockedByPatches(node: PathNode, patches: Set<string>): boolean {
+  const blocked = node.gate?.blocked ?? [];
+  return blocked.some(block => patches.has(block));
+}
+
+async function emitTimeline(
+  publisher: TimelinePublisher | undefined,
+  worldId: WorldId,
+  node: PathNode,
+  eventType: string,
+  description: string,
+  metadata?: Record<string, unknown>
+) {
+  if (!publisher) return;
+
+  const event: CreateTimelineEvent = {
+    worldId,
+    eventType,
+    description,
+    metadata: {
+      nodeId: node.id,
+      nodeTitle: node.title,
+      ...node.timeline?.metadata,
+      ...metadata
+    }
+  };
+
+  await publisher(event);
+}
+
+class DefaultPathEngine implements PathEngineType {
+  world: WorldId;
+  path: PathDefinition;
+  currentNode: PathNode;
+  history: string[];
+  private patches: Set<string>;
+  private publisher?: TimelinePublisher;
+
+  constructor(path: PathDefinition, options?: PathEngineOptions) {
+    this.path = path;
+    this.world = path.world;
+    this.patches = new Set(options?.patches?.map(patch => patch.id) ?? []);
+    this.publisher = options?.timelinePublisher;
+    this.currentNode = this.path.nodes[this.path.start];
+    this.history = [this.currentNode.id];
+  }
+
+  getAvailableNext(): PathNode[] {
+    const nextIds = this.currentNode.next ?? [];
+    return nextIds
+      .map(id => this.path.nodes[id])
+      .filter(node => !!node && this.canEnter(node.id));
+  }
+
+  canEnter(nodeId: string): boolean {
+    const node = this.path.nodes[nodeId];
+    if (!node) return false;
+    if (!hasRequiredPatches(node, this.patches)) return false;
+    if (isBlockedByPatches(node, this.patches)) return false;
+    return true;
+  }
+
+  async enter(nodeId: string, metadata?: Record<string, unknown>): Promise<PathNode> {
+    const node = this.path.nodes[nodeId];
+    if (!node) {
+      throw new Error(`Path node ${nodeId} not found for world ${this.world}`);
+    }
+
+    if (!this.currentNode.next?.includes(nodeId)) {
+      throw new Error(`Node ${nodeId} is not reachable from ${this.currentNode.id}`);
+    }
+
+    if (!this.canEnter(nodeId)) {
+      throw new Error(`Node ${nodeId} cannot be entered because of patch gating`);
+    }
+
+    this.currentNode = node;
+    this.history.push(node.id);
+
+    await emitTimeline(
+      this.publisher,
+      this.world,
+      node,
+      node.timeline?.enterEventType ?? DEFAULT_ENTER_EVENT,
+      `Entered ${node.title}`,
+      metadata
+    );
+
+    return this.currentNode;
+  }
+
+  async complete(
+    nextNodeId?: string,
+    metadata?: Record<string, unknown>
+  ): Promise<PathNode | null> {
+    const completed = this.currentNode;
+
+    await emitTimeline(
+      this.publisher,
+      this.world,
+      completed,
+      completed.timeline?.completeEventType ?? DEFAULT_COMPLETE_EVENT,
+      `Completed ${completed.title}`,
+      metadata
+    );
+
+    if (!nextNodeId) {
+      return null;
+    }
+
+    return this.enter(nextNodeId, metadata);
+  }
+}
+
+const pathEngineCache = new Map<WorldId, DefaultPathEngine>();
+
+export function usePathEngine(world: WorldId, options?: PathEngineOptions): PathEngineType {
+  const path = pathDefinitions[world];
+  if (!path) {
+    throw new Error(`No path definition registered for world ${world}`);
+  }
+
+  if (!options) {
+    const existingEngine = pathEngineCache.get(world);
+    if (existingEngine) {
+      return existingEngine;
+    }
+  }
+
+  const engine = new DefaultPathEngine(path, options);
+
+  if (!options) {
+    pathEngineCache.set(world, engine);
+  }
+
+  return engine;
+}
+
+export type PathEngine = PathEngineType;
+export { pathDefinitions };

--- a/src/lib/pathEngine/paths.ts
+++ b/src/lib/pathEngine/paths.ts
@@ -1,0 +1,85 @@
+import { PathDefinition, WorldId } from '../../types/pathEngine.js';
+
+function buildCanonPath(
+  world: WorldId,
+  stages: Array<{
+    id: string;
+    title: string;
+    description: string;
+  }>,
+  gating: { required?: string[]; blocked?: string[] }
+): PathDefinition {
+  const nodes: PathDefinition['nodes'] = {};
+
+  stages.forEach((stage, index) => {
+    const nextStage = stages[index + 1];
+    nodes[stage.id] = {
+      id: stage.id,
+      title: stage.title,
+      description: stage.description,
+      world,
+      next: nextStage ? [nextStage.id] : [],
+      gate: index === 0
+        ? undefined
+        : {
+            required: gating.required,
+            blocked: gating.blocked,
+            description: 'Patch-gated progression using the same rules as the NPC reference path.'
+          },
+      timeline: {
+        metadata: { stage: stage.id, world }
+      }
+    };
+  });
+
+  return {
+    world,
+    start: stages[0]?.id ?? '',
+    nodes
+  };
+}
+
+export const pathDefinitions: Record<WorldId, PathDefinition> = {
+  '3DT': buildCanonPath(
+    '3DT',
+    [
+      { id: 'boot', title: 'NPC Boot', description: 'NPC wakes up inside the 3DT simulation.' },
+      { id: 'sense', title: 'Sense World', description: 'Gather world context and player intent.' },
+      { id: 'plan', title: 'Plan Response', description: 'Draft a safe, canon-aligned plan for the NPC.' },
+      { id: 'act', title: 'Act', description: 'Perform the action using the agreed plan.' },
+      { id: 'reflect', title: 'Reflect', description: 'Log observations and prepare for the next loop.' }
+    ],
+    {
+      required: ['NPC_CANON_READY'],
+      blocked: ['NPC_MAINTENANCE']
+    }
+  ),
+  AKIRA_CODEX: buildCanonPath(
+    'AKIRA_CODEX',
+    [
+      { id: 'ingest', title: 'Ingest Text', description: 'Load codex entry and prepare reading context.' },
+      { id: 'interpret', title: 'Interpret', description: 'Summarize and align with canon reading paths.' },
+      { id: 'canonize', title: 'Canonize', description: 'Validate canon and mark authoritative take.' },
+      { id: 'broadcast', title: 'Broadcast', description: 'Share the canon interpretation with listeners.' },
+      { id: 'archive', title: 'Archive', description: 'Record the interaction and store provenance.' }
+    ],
+    {
+      required: ['CANON_PATCH_APPLIED'],
+      blocked: ['READ_ONLY_MODE']
+    }
+  ),
+  CREATOR_CODEX: buildCanonPath(
+    'CREATOR_CODEX',
+    [
+      { id: 'draft', title: 'Draft', description: 'Initial creative draft aligned to creator goals.' },
+      { id: 'refine', title: 'Refine', description: 'Iterate with feedback while respecting canon.' },
+      { id: 'proof', title: 'Proof', description: 'Verify safety, ethics, and compliance.' },
+      { id: 'publish', title: 'Publish', description: 'Release to the studio output stream.' },
+      { id: 'followup', title: 'Follow-up', description: 'Gather reactions and prime the next draft.' }
+    ],
+    {
+      required: ['CREATOR_CANON_READY'],
+      blocked: ['CREATOR_HOLD']
+    }
+  )
+};

--- a/src/types/pathEngine.ts
+++ b/src/types/pathEngine.ts
@@ -1,0 +1,56 @@
+import { Patch, CreateTimelineEvent } from './registry.js';
+
+export type WorldId = '3DT' | 'AKIRA_CODEX' | 'CREATOR_CODEX';
+
+export interface PatchGate {
+  /** Patches that must be present for the node to be enterable */
+  required?: string[];
+  /** Patches that block progress if present */
+  blocked?: string[];
+  description?: string;
+}
+
+export interface TimelineConfig {
+  /** Event type for entering the node (defaults to PATH_NODE_ENTERED) */
+  enterEventType?: string;
+  /** Event type for completing the node (defaults to PATH_NODE_COMPLETED) */
+  completeEventType?: string;
+  /** Additional metadata that should always be included on emitted events */
+  metadata?: Record<string, unknown>;
+}
+
+export interface PathNode {
+  id: string;
+  title: string;
+  description?: string;
+  world: WorldId;
+  /** Next node IDs available from this node */
+  next?: string[];
+  gate?: PatchGate;
+  timeline?: TimelineConfig;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PathDefinition {
+  world: WorldId;
+  start: string;
+  nodes: Record<string, PathNode>;
+}
+
+export type TimelinePublisher = (event: CreateTimelineEvent) => Promise<void> | void;
+
+export interface PathEngineOptions {
+  patches?: Patch[];
+  timelinePublisher?: TimelinePublisher;
+}
+
+export interface PathEngine {
+  world: WorldId;
+  path: PathDefinition;
+  currentNode: PathNode;
+  history: string[];
+  getAvailableNext(): PathNode[];
+  canEnter(nodeId: string): boolean;
+  enter(nodeId: string, metadata?: Record<string, unknown>): Promise<PathNode>;
+  complete(nextNodeId?: string, metadata?: Record<string, unknown>): Promise<PathNode | null>;
+}


### PR DESCRIPTION
## Summary
- add reusable path engine types with patch gating and timeline emission
- provide usePathEngine helper that reuses per-world engines when no custom options are passed
- define example canonical paths for 3DT NPCs, Akira Codex reading, and Creator Codex publishing flows

## Testing
- npm run build *(fails: existing TypeScript errors for missing Prisma enums and typings in lib/economy/billing.ts and src/server.ts)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694758cba94c8327bb90bdaf8711fe05)