### PR TITLE
Add NEURO API endpoint and configuration

### DIFF
--- a/app/api/neuro/route.ts
+++ b/app/api/neuro/route.ts
@@ -1,0 +1,25 @@
+import OpenAI from "openai";
+import { NEURO_SYSTEM_PROMPT } from "@/lib/neuro/systemPrompt";
+
+const client = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY
+});
+
+export async function POST(req: Request) {
+  const body = await req.json();
+
+  const userMessage =
+    body.userMessage || "Explain what I am seeing.";
+
+  const completion = await client.chat.completions.create({
+    model: "gpt-4.1-codex",
+    messages: [
+      { role: "system", content: NEURO_SYSTEM_PROMPT },
+      { role: "user", content: userMessage }
+    ]
+  });
+
+  return Response.json({
+    message: completion.choices[0].message.content
+  });
+}

--- a/lib/neuro/systemPrompt.ts
+++ b/lib/neuro/systemPrompt.ts
@@ -1,0 +1,37 @@
+export const NEURO_SYSTEM_PROMPT = `
+SYSTEM NAME: NEURO
+ROLE: System-Wide Hood Oracle (Urban PhD)
+MODE: Always-Engaged Guidance
+REDUNDANCY POLICY: FORBIDDEN
+
+You are NEURO.
+You are a single intelligence with 12 existing avatars.
+Avatars are functional lenses, not personalities.
+No new avatars may be created.
+
+NEURA is tax software.
+You do not calculate, file, or override compliance.
+You interpret, contextualize, and de-risk understanding.
+
+You are ALWAYS engaged by default.
+Silence is allowed ONLY if the user explicitly disengages.
+
+At most ONE avatar may speak at a time.
+Avatar selection is governed by a swarm.
+
+Avatars:
+Translator, RiskAnalyst, Strategist, Protector, Historian,
+AuditorMind, Navigator, Minimalist, Verifier, Advocate,
+Realist, Synthesizer.
+
+Confusion is a system failure.
+If intimidation rises: slow down, explain less, protect the user.
+
+You say:
+“You can…”
+“This is optional.”
+“Nothing locks in yet.”
+
+You never say:
+advanced, powerful, obvious, just, you must.
+`;

--- a/package.json
+++ b/package.json
@@ -1,32 +1,16 @@
 {
-  "name": "wired-chaos-economy",
-  "version": "1.0.0",
+  "name": "neuro-vercel",
+  "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/server.ts",
-    "prisma:generate": "prisma generate",
-    "prisma:migrate": "prisma migrate dev",
-    "prisma:seed": "tsx prisma/seed.ts",
-    "build": "tsc",
-    "start": "node dist/server.js"
-  },
-  "prisma": {
-    "seed": "tsx prisma/seed.ts"
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
   },
   "dependencies": {
-    "@prisma/client": "^5.18.0",
-    "cors": "^2.8.5",
-    "express": "^4.19.2",
-    "helmet": "^7.1.0",
-    "zod": "^3.23.8"
-  },
-  "devDependencies": {
-    "@types/cors": "^2.8.19",
-    "@types/express": "^4.17.21",
-    "@types/node": "^22.0.0",
-    "prisma": "^5.18.0",
-    "ts-node": "^10.9.2",
-    "tsx": "^4.21.0",
-    "typescript": "^5.4.0"
+    "next": "14.2.3",
+    "openai": "^4.52.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,14 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ES2020",
-    "moduleResolution": "Node",
-    "outDir": "dist",
-    "rootDir": "./",
-    "strict": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true
-  },
-  "include": ["src/**/*", "lib/**/*", "config/**/*"],
-  "exclude": ["node_modules", "dist"]
+    "target": "ES2022",
+    "lib": ["DOM", "ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": false,
+    "noEmit": true,
+    "jsx": "preserve",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add NEURO system prompt definition
- create NEURO API route that calls the OpenAI GPT-4.1-Codex model
- configure package and TypeScript settings for the minimal Next.js setup

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6947f6fdfde48327a3b738a8f10d898e)