### PR TITLE
Add WIRED CHAOS META monorepo scaffolding

### DIFF
--- a/wired-chaos-meta/apps/web/next.config.mjs
+++ b/wired-chaos-meta/apps/web/next.config.mjs
@@ -1,0 +1,3 @@
+const nextConfig = {};
+
+export default nextConfig;

--- a/wired-chaos-meta/apps/web/package.json
+++ b/wired-chaos-meta/apps/web/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@wcmeta/web",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev -p 3000",
+    "build": "next build",
+    "lint": "next lint",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@wcmeta/core": "workspace:*",
+    "@wcmeta/doge-inscriptions": "workspace:*",
+    "@wcmeta/evm": "workspace:*",
+    "next": "14.2.16",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "zod": "^3.23.8"
+  }
+}

--- a/wired-chaos-meta/apps/web/src/app/api/auth/nonce/route.ts
+++ b/wired-chaos-meta/apps/web/src/app/api/auth/nonce/route.ts
@@ -1,0 +1,6 @@
+import crypto from "node:crypto";
+
+export async function GET() {
+  const nonce = crypto.randomBytes(16).toString("hex");
+  return Response.json({ ok: true, nonce });
+}

--- a/wired-chaos-meta/apps/web/src/app/api/auth/verify/route.ts
+++ b/wired-chaos-meta/apps/web/src/app/api/auth/verify/route.ts
@@ -1,0 +1,5 @@
+export async function POST(req: Request) {
+  const body = await req.json();
+  // Placeholder verification logic; integrate JWT/domain checks as needed.
+  return Response.json({ ok: true, received: body });
+}

--- a/wired-chaos-meta/apps/web/src/app/api/credentials/doge/mint/route.ts
+++ b/wired-chaos-meta/apps/web/src/app/api/credentials/doge/mint/route.ts
@@ -1,0 +1,33 @@
+import { CredentialPayload, CredentialType } from "@wcmeta/doge-inscriptions";
+import { newNonce, buildInscriptionContent } from "@wcmeta/doge-inscriptions";
+import { canAccess } from "@wcmeta/core";
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const { tier = "FREE", type, subject, program, issuer = "WIRED_CHAOS", issuedAt } = body ?? {};
+
+  // FREE users can mint, but they pay the network fee. We simply generate the payload.
+  const access = canAccess(tier, "MINT_CREDENTIAL_DOGE");
+  if (!access.ok) return Response.json({ ok: false, error: access.reason }, { status: 403 });
+
+  const payload = CredentialPayload.parse({
+    v: 1,
+    type: CredentialType.parse(type),
+    subject: String(subject),
+    issuer: String(issuer),
+    program: String(program),
+    issuedAt: issuedAt ? String(issuedAt) : new Date().toISOString(),
+    nonce: newNonce()
+  });
+
+  const content = buildInscriptionContent(payload);
+
+  // Production: hand this to your DOGE mint worker (doginals CLI wrapper) to broadcast.
+  return Response.json({
+    ok: true,
+    note: "User pays network mint fee. This endpoint prepares inscription content.",
+    payload,
+    contentBase64: content.toString("base64"),
+    contentUtf8: content.toString("utf8")
+  });
+}

--- a/wired-chaos-meta/apps/web/src/app/api/credentials/doge/verify/route.ts
+++ b/wired-chaos-meta/apps/web/src/app/api/credentials/doge/verify/route.ts
@@ -1,0 +1,15 @@
+import { parseCredential } from "@wcmeta/doge-inscriptions";
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const { contentBase64, contentUtf8 } = body ?? {};
+
+  if (!contentBase64 && !contentUtf8) {
+    return Response.json({ ok: false, error: "contentBase64 or contentUtf8 is required" }, { status: 400 });
+  }
+
+  const utf8 = contentUtf8 ?? Buffer.from(String(contentBase64), "base64").toString("utf8");
+  const credential = parseCredential(utf8);
+
+  return Response.json({ ok: true, credential });
+}

--- a/wired-chaos-meta/apps/web/src/app/api/eth/owns/route.ts
+++ b/wired-chaos-meta/apps/web/src/app/api/eth/owns/route.ts
@@ -1,0 +1,20 @@
+import { ownsErc721 } from "@wcmeta/evm";
+import { env } from "@/lib/env";
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const { contract, owner } = body ?? {};
+
+  if (!contract || !owner) {
+    return Response.json({ ok: false, error: "Missing contract or owner" }, { status: 400 });
+  }
+
+  const ok = await ownsErc721({
+    chain: "ETH",
+    rpcUrl: env.EVM_RPC_ETH,
+    contract,
+    owner
+  });
+
+  return Response.json({ ok: true, owns: ok });
+}

--- a/wired-chaos-meta/apps/web/src/app/api/health/route.ts
+++ b/wired-chaos-meta/apps/web/src/app/api/health/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+  return Response.json({ ok: true, name: "wired-chaos-meta", ts: new Date().toISOString() });
+}

--- a/wired-chaos-meta/apps/web/src/app/api/receipts/log/route.ts
+++ b/wired-chaos-meta/apps/web/src/app/api/receipts/log/route.ts
@@ -1,0 +1,8 @@
+import { Receipt } from "@wcmeta/core";
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const receipt = Receipt.parse(body);
+  // In production, persist receipt to your datastore or Hedera leg.
+  return Response.json({ ok: true, receipt });
+}

--- a/wired-chaos-meta/apps/web/src/app/api/router/route.ts
+++ b/wired-chaos-meta/apps/web/src/app/api/router/route.ts
@@ -1,0 +1,8 @@
+import { routeIntent, Intent } from "@wcmeta/core";
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const intent = Intent.parse(body?.intent);
+  const chain = routeIntent(intent);
+  return Response.json({ ok: true, intent, chain });
+}

--- a/wired-chaos-meta/apps/web/src/app/layout.tsx
+++ b/wired-chaos-meta/apps/web/src/app/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+export const metadata = {
+  title: "WIRED CHAOS META",
+  description: "Chain-agnostic identity + credential router"
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/wired-chaos-meta/apps/web/src/app/page.tsx
+++ b/wired-chaos-meta/apps/web/src/app/page.tsx
@@ -1,0 +1,9 @@
+export default function Home() {
+  return (
+    <main style={{ padding: 24, fontFamily: "sans-serif" }}>
+      <h1>WIRED CHAOS META</h1>
+      <p>Chain-agnostic credentials + router (DOGE inscriptions, Base actions, ETH read-only).</p>
+      <p>Use the API routes to interact with the system.</p>
+    </main>
+  );
+}

--- a/wired-chaos-meta/apps/web/src/lib/env.ts
+++ b/wired-chaos-meta/apps/web/src/lib/env.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+const Env = z.object({
+  WC_META_JWT_SECRET: z.string().min(16),
+  WC_META_DOMAIN: z.string(),
+
+  EVM_RPC_BASE: z.string().url(),
+  EVM_RPC_ETH: z.string().url(),
+
+  DOGE_NETWORK: z.enum(["mainnet", "testnet"]).default("mainnet"),
+  DOGE_RPC_URL: z.string().optional(),
+  DOGE_RPC_USER: z.string().optional(),
+  DOGE_RPC_PASS: z.string().optional(),
+  DOGE_MINT_WIF: z.string().optional()
+});
+
+export const env = Env.parse(process.env);

--- a/wired-chaos-meta/apps/web/src/lib/security.ts
+++ b/wired-chaos-meta/apps/web/src/lib/security.ts
@@ -1,0 +1,5 @@
+import crypto from "node:crypto";
+
+export function signMessage(secret: string, message: string): string {
+  return crypto.createHmac("sha256", secret).update(message).digest("hex");
+}

--- a/wired-chaos-meta/apps/web/src/lib/wcmeta.ts
+++ b/wired-chaos-meta/apps/web/src/lib/wcmeta.ts
@@ -1,0 +1,7 @@
+import { canAccess, routeIntent, Intent, Tier } from "@wcmeta/core";
+
+export function checkAccess(tier: Tier, intent: Intent) {
+  const access = canAccess(tier, intent);
+  const chain = routeIntent(intent);
+  return { ...access, chain };
+}

--- a/wired-chaos-meta/apps/web/tsconfig.json
+++ b/wired-chaos-meta/apps/web/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "./src/**/*.ts", "./src/**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/wired-chaos-meta/package.json
+++ b/wired-chaos-meta/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "wired-chaos-meta",
+  "private": true,
+  "packageManager": "pnpm@9.12.3",
+  "scripts": {
+    "dev": "turbo dev",
+    "build": "turbo build",
+    "lint": "turbo lint",
+    "typecheck": "turbo typecheck"
+  },
+  "devDependencies": {
+    "turbo": "^2.1.3",
+    "typescript": "^5.6.3"
+  }
+}

--- a/wired-chaos-meta/packages/adapters/doge-inscriptions/package.json
+++ b/wired-chaos-meta/packages/adapters/doge-inscriptions/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@wcmeta/doge-inscriptions",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "dependencies": {
+    "zod": "^3.23.8"
+  }
+}

--- a/wired-chaos-meta/packages/adapters/doge-inscriptions/src/index.ts
+++ b/wired-chaos-meta/packages/adapters/doge-inscriptions/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./schema";
+export * from "./mint";
+export * from "./verify";

--- a/wired-chaos-meta/packages/adapters/doge-inscriptions/src/mint.ts
+++ b/wired-chaos-meta/packages/adapters/doge-inscriptions/src/mint.ts
@@ -1,0 +1,22 @@
+import crypto from "node:crypto";
+import { CredentialPayload } from "./schema";
+
+/**
+ * Production note:
+ * Dogecoin inscription minting generally requires building/signing a Dogecoin tx
+ * that carries the inscription content and broadcasting via Dogecoin RPC.
+ *
+ * Here we produce the content bytes and return an object that a "doginals" CLI
+ * wrapper can use to construct and broadcast the transaction.
+ *
+ * This keeps the adapter chain-agnostic and lets you swap mint engines.
+ */
+export function buildInscriptionContent(payload: CredentialPayload): Buffer {
+  const json = JSON.stringify(payload);
+  // keep payload lean; inscriptions are permanent
+  return Buffer.from(json, "utf8");
+}
+
+export function newNonce(): string {
+  return crypto.randomBytes(16).toString("hex");
+}

--- a/wired-chaos-meta/packages/adapters/doge-inscriptions/src/schema.ts
+++ b/wired-chaos-meta/packages/adapters/doge-inscriptions/src/schema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+// Minimal credential schema for inscriptions (small + verifiable).
+export const CredentialType = z.enum(["SCHOOL_ID", "CERTIFICATE", "CREDENTIAL"]);
+
+export const CredentialPayload = z.object({
+  v: z.literal(1),
+  type: CredentialType,
+  subject: z.string(),        // user identifier (wallet address, or DID)
+  issuer: z.string(),         // WIRED CHAOS issuer id
+  program: z.string(),        // course / track id
+  issuedAt: z.string(),       // ISO date
+  nonce: z.string(),          // anti-replay
+  sig: z.string().optional()  // optional issuer signature (off-chain signing)
+});
+
+export type CredentialPayload = z.infer<typeof CredentialPayload>;

--- a/wired-chaos-meta/packages/adapters/doge-inscriptions/src/verify.ts
+++ b/wired-chaos-meta/packages/adapters/doge-inscriptions/src/verify.ts
@@ -1,0 +1,6 @@
+import { CredentialPayload } from "./schema";
+
+export function parseCredential(contentUtf8: string): CredentialPayload {
+  const obj = JSON.parse(contentUtf8);
+  return CredentialPayload.parse(obj);
+}

--- a/wired-chaos-meta/packages/adapters/evm/package.json
+++ b/wired-chaos-meta/packages/adapters/evm/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@wcmeta/evm",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "dependencies": {
+    "viem": "^2.21.41"
+  }
+}

--- a/wired-chaos-meta/packages/adapters/evm/src/index.ts
+++ b/wired-chaos-meta/packages/adapters/evm/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./readNft";

--- a/wired-chaos-meta/packages/adapters/evm/src/readNft.ts
+++ b/wired-chaos-meta/packages/adapters/evm/src/readNft.ts
@@ -1,0 +1,30 @@
+import { createPublicClient, http, getAddress } from "viem";
+import { mainnet, base } from "viem/chains";
+
+// ERC-721 balanceOf(address)
+const erc721Abi = [{
+  "type": "function",
+  "name": "balanceOf",
+  "stateMutability": "view",
+  "inputs": [{ "name": "owner", "type": "address" }],
+  "outputs": [{ "name": "balance", "type": "uint256" }]
+}] as const;
+
+export async function ownsErc721(opts: {
+  chain: "ETH" | "BASE";
+  rpcUrl: string;
+  contract: string;
+  owner: string;
+}): Promise<boolean> {
+  const chain = opts.chain === "ETH" ? mainnet : base;
+  const client = createPublicClient({ chain, transport: http(opts.rpcUrl) });
+
+  const bal = await client.readContract({
+    address: getAddress(opts.contract),
+    abi: erc721Abi,
+    functionName: "balanceOf",
+    args: [getAddress(opts.owner)]
+  });
+
+  return bal > 0n;
+}

--- a/wired-chaos-meta/packages/adapters/hedera/package.json
+++ b/wired-chaos-meta/packages/adapters/hedera/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@wcmeta/hedera",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts"
+}

--- a/wired-chaos-meta/packages/adapters/hedera/src/index.ts
+++ b/wired-chaos-meta/packages/adapters/hedera/src/index.ts
@@ -1,0 +1,2 @@
+// Hedera receipts/logging adapter placeholder.
+export {};

--- a/wired-chaos-meta/packages/adapters/hedera/src/receipts.ts
+++ b/wired-chaos-meta/packages/adapters/hedera/src/receipts.ts
@@ -1,0 +1,2 @@
+// Receipt logging utilities for Hedera to be implemented.
+export {};

--- a/wired-chaos-meta/packages/adapters/solana/package.json
+++ b/wired-chaos-meta/packages/adapters/solana/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@wcmeta/solana",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts"
+}

--- a/wired-chaos-meta/packages/adapters/solana/src/index.ts
+++ b/wired-chaos-meta/packages/adapters/solana/src/index.ts
@@ -1,0 +1,2 @@
+// Solana live events/proofs adapter placeholder.
+export {};

--- a/wired-chaos-meta/packages/adapters/solana/src/proofs.ts
+++ b/wired-chaos-meta/packages/adapters/solana/src/proofs.ts
@@ -1,0 +1,2 @@
+// Solana proof utilities to be added when enabling this leg.
+export {};

--- a/wired-chaos-meta/packages/adapters/xrpl/package.json
+++ b/wired-chaos-meta/packages/adapters/xrpl/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@wcmeta/xrpl",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts"
+}

--- a/wired-chaos-meta/packages/adapters/xrpl/src/index.ts
+++ b/wired-chaos-meta/packages/adapters/xrpl/src/index.ts
@@ -1,0 +1,3 @@
+// XRPL adapter placeholder for optional payment rails.
+// Implement payments and connection handling when enabling this leg.
+export {};

--- a/wired-chaos-meta/packages/adapters/xrpl/src/payments.ts
+++ b/wired-chaos-meta/packages/adapters/xrpl/src/payments.ts
@@ -1,0 +1,2 @@
+// XRPL payment utilities will live here.
+export {};

--- a/wired-chaos-meta/packages/core/package.json
+++ b/wired-chaos-meta/packages/core/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@wcmeta/core",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "type": "module",
+  "dependencies": {
+    "zod": "^3.23.8"
+  }
+}

--- a/wired-chaos-meta/packages/core/src/index.ts
+++ b/wired-chaos-meta/packages/core/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./policy";
+export * from "./router";

--- a/wired-chaos-meta/packages/core/src/policy.ts
+++ b/wired-chaos-meta/packages/core/src/policy.ts
@@ -1,0 +1,18 @@
+import { Tier, Intent } from "./types";
+
+export function canAccess(tier: Tier, intent: Intent): { ok: boolean; reason?: string } {
+  // System law:
+  // - FREE users can use core system without subscription
+  // - FREE users may still pay network minting fees if they choose to mint
+  // - Restricted content / tokengates are not accessible for FREE
+  const restricted: Intent[] = [
+    "EXECUTE_BASE_ACTION", // example: advanced automation action
+    "XRPL_PAYMENT",        // example: could be gated
+    "SOL_PROOF"            // example: live event perks
+  ];
+
+  if (tier === "FREE" && restricted.includes(intent)) {
+    return { ok: false, reason: "Restricted to paid or tokengated tiers." };
+  }
+  return { ok: true };
+}

--- a/wired-chaos-meta/packages/core/src/router.ts
+++ b/wired-chaos-meta/packages/core/src/router.ts
@@ -1,0 +1,21 @@
+import { Intent, Chain } from "./types";
+
+export function routeIntent(intent: Intent): Chain {
+  switch (intent) {
+    case "MINT_CREDENTIAL_DOGE":
+    case "VERIFY_CREDENTIAL_DOGE":
+      return "DOGE";
+    case "ETH_NFT_OWNERSHIP_CHECK":
+      return "ETH"; // read-only
+    case "EXECUTE_BASE_ACTION":
+      return "BASE";
+    case "XRPL_PAYMENT":
+      return "XRP";
+    case "LOG_RECEIPT":
+      return "HBAR";
+    case "SOL_PROOF":
+      return "SOL";
+    default:
+      return "BASE";
+  }
+}

--- a/wired-chaos-meta/packages/core/src/types.ts
+++ b/wired-chaos-meta/packages/core/src/types.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+export const Tier = z.enum(["FREE", "PRO", "TOKEN_GATED"]);
+export type Tier = z.infer<typeof Tier>;
+
+export const Chain = z.enum(["DOGE", "BASE", "ETH", "XRP", "HBAR", "SOL"]);
+export type Chain = z.infer<typeof Chain>;
+
+export const Intent = z.enum([
+  "READ_IDENTITY",
+  "MINT_CREDENTIAL_DOGE",
+  "VERIFY_CREDENTIAL_DOGE",
+  "ETH_NFT_OWNERSHIP_CHECK",
+  "EXECUTE_BASE_ACTION",
+  "LOG_RECEIPT",
+  "XRPL_PAYMENT",
+  "SOL_PROOF"
+]);
+export type Intent = z.infer<typeof Intent>;
+
+export const Receipt = z.object({
+  id: z.string(),
+  ts: z.string(),
+  intent: Intent,
+  chain: Chain.optional(),
+  actor: z.string().optional(),
+  summary: z.string(),
+  meta: z.record(z.any()).optional()
+});
+export type Receipt = z.infer<typeof Receipt>;

--- a/wired-chaos-meta/tsconfig.base.json
+++ b/wired-chaos-meta/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  }
+}

--- a/wired-chaos-meta/turbo.json
+++ b/wired-chaos-meta/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "dev": { "cache": false, "persistent": true },
+    "build": { "dependsOn": ["^build"], "outputs": ["dist/**", ".next/**"] },
+    "lint": {},
+    "typecheck": {}
+  }
+}


### PR DESCRIPTION
## Summary
- add WIRED CHAOS META pnpm/turbo monorepo scaffold with base configs and env template
- implement core types, policy, and routing utilities alongside DOGE inscription and EVM adapters
- expose Next.js API endpoints for health, routing, DOGE credential minting/verification, ETH NFT checks, and placeholders for receipts/auth

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694f049c811c8327a9f4c79913cfae32)