### PR TITLE
Add CITIZ3N.H3X canonical perimeter spec

### DIFF
--- a/_exports/DOC_INDEX.md
+++ b/_exports/DOC_INDEX.md
@@ -16,3 +16,7 @@
 | FASHION_DESIGN_SWARM.md | WIRED CHAOS META — FASHION DESIGN SWARM (FDS-1) | 2025-12-19 | Swarm-based onboarding blueprint for fashion designers covering agents, curriculum, mint rules, vault/DCA, and commerce flows.【F:FASHION_DESIGN_SWARM.md†L1-L69】 |
 | UPLOAD_CONTRACT.md | Upload Contract (Non-Developer Safe) | 2025-12-19 | Rules for placing ZIPs in INBOX_UPLOADS, automation behaviors, and verification steps post-ingest.【F:UPLOAD_CONTRACT.md†L1-L16】 |
 | PRODUCTION_CHECKLIST.md | Production Checklist (ZIP Ingest) | 2025-12-19 | Checklist for upload, automation, verification, and merge phases of ZIP ingest workflow.【F:PRODUCTION_CHECKLIST.md†L1-L17】 |
+| docs/CITIZ3N_H3X_CANON.md | CITIZ3N.H3X — Canonical Perimeter Spec | 2025-12-19 | Defines CITIZ3N.H3X as a spatial perimeter city, mapping hex zones, embassies, foundry systems, agents, governance, and failure states to physical metaphors.【F:docs/CITIZ3N_H3X_CANON.md†L1-L97】 |
+
+## Changelog
+- 2025-12-19: Added the CITIZ3N.H3X canonical perimeter specification to the system doc index.

--- a/docs/CITIZ3N_H3X_CANON.md
+++ b/docs/CITIZ3N_H3X_CANON.md
@@ -1,0 +1,110 @@
+# CITIZ3N.H3X — Canonical Perimeter Spec
+
+CITIZ3N.H3X is the living perimeter interface that surrounds the WIRED CHAOS Swarm Room.
+It is not a dashboard, repo browser, or settings panel.
+It is the hex-grid city you traverse before entering deeper rooms.
+
+## Core Identity
+- **Terrain, not UI:** Users arrive in a city, not a screen.
+- **Streets, not menus:** Navigation is spatial and directional.
+- **Districts, not tabs:** Capabilities are neighborhoods with rules and mood.
+- **Checkpoints, not popups:** Trust, scope, and permission are felt as gates.
+
+## Spatial Reframe of Core Components
+
+### 1) The Hex Grid (Zones of Capability)
+Each hex represents a zone with:
+- a function cluster
+- a permission boundary
+- a trust level
+- a system state
+
+Behavioral rules:
+- **Inactive hexes** feel cold, dim, distant, or silent.
+- **Active hexes** hum, flicker, or draw attention.
+- **Boundary crossing** is a deliberate decision; the city acknowledges the crossing.
+
+### 2) Integrations (Foreign Embassies)
+Integrations are no longer connected services. They are embassies inside the city.
+
+Each embassy:
+- occupies its own structure
+- has guards (auth, scopes, tokens)
+- exposes only specific doors
+- reacts to your standing
+
+Canonical mappings:
+- **Blender** → Blender District (creative assembly ward)
+- **Godot** → Simulation Ward (world-building sector)
+- **dYad** → Fabrication Quarter (forging / synthesis zone)
+- **Vercel** → Deployment Consulate (launch corridor)
+- **GitHub** → Archive & Treaty House (source-truth gate)
+
+Failure behavior:
+- Embassies **lock, flicker, or evacuate**. They do not show generic errors.
+- An unavailable embassy **recedes** rather than breaking the city.
+
+### 3) Build System & Dev Tools (The Foundry)
+Build pipelines are physical, not textual.
+
+Rules:
+- You **approach** the foundry to initiate a build.
+- You **place artifacts** into it to start ignition.
+- **Warnings** appear as sparks.
+- **Errors** appear as cracks or structural strain.
+- **Success** becomes a completed object you can inspect.
+
+State meaning:
+- Blank output means **the foundry never lit** (a state, not a bug).
+
+### 4) Agents in CITIZ3N.H3X (Sentinels, Runners, Engineers)
+These are not core WIRED CHAOS agents. They are perimeter actors.
+
+Roles:
+- **Sentinels** patrol boundaries and watch trust edges.
+- **Runners** escort artifacts between districts.
+- **Engineers** intervene when flows stall or systems degrade.
+
+Behavior:
+- If nothing is happening, they **idle**.
+- If something breaks, they **converge**.
+- You do not read logs; you **watch their reactions**.
+
+### 5) Governance in the Perimeter (Border Control)
+Governance is expressed as spatial access and response.
+
+Rules:
+- **Deploy / patch / fork / observe / override** are spatial privileges.
+- Low-trust users **see powerful zones** but cannot enter them.
+- Audited systems feel tense: **paths narrow, agents cluster**.
+
+Governance is felt, not explained.
+
+## Relationship to WIRED CHAOS META
+CITIZ3N.H3X is outside the Swarm Room but inside the world.
+
+Flow:
+1. User arrives in the **CITIZ3N.H3X perimeter city**.
+2. They traverse **hex districts** (capabilities, builds, integrations).
+3. They cross a **threshold**.
+4. They enter the **WIRED CHAOS Swarm Room** (core intelligence).
+
+“Flat SaaS mode” becomes a static map of the city viewed from above—functional, but dead.
+
+## State Clarity (Resolved Ambiguity)
+- “Nothing happens” → **No agents are active.**
+- “Output blank” → **You are in an unpowered zone.**
+- “System doesn’t do anything” → **No ritual was triggered.**
+
+## Canonical Rule Going Forward
+For every CITIZ3N.H3X element, answer:
+1. Where does this exist spatially?
+2. What does it feel like to approach?
+3. Who guards it?
+4. What changes when it activates?
+5. What does failure look like in space?
+
+If a component cannot answer these, it does not belong in CITIZ3N.H3X.
+
+## Changelog
+- 2025-12-19: Established the canonical perimeter specification for CITIZ3N.H3X and mapped all core moving parts to spatial behaviors.


### PR DESCRIPTION
### Motivation
- Formalize the new spatial "hex-city" perimeter model for CITIZ3N.H3X so that perimeter behaviors, integrations, build semantics, agents, and governance are expressed as terrain and states rather than UI metaphors.

### Description
- Add `docs/CITIZ3N_H3X_CANON.md` containing the canonical perimeter specification describing hex zones, embassies (integrations), the foundry (build system), perimeter agents, governance-as-border-control, and failure states.
- Update `_exports/DOC_INDEX.md` to index the new spec and add a changelog entry documenting the addition.

### Testing
- No automated tests were run because this is a documentation-only change; validation consisted of committing the new file and updating the doc index without code modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696fa76f142c83279a349761a9b1a0b8)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a canonical spec defining CITIZ3N.H3X as a spatial perimeter model and updates the doc index accordingly.
> 
> - Adds `docs/CITIZ3N_H3X_CANON.md` detailing hex zones, embassies (integrations), the foundry (build system), perimeter agents, governance-as-border-control, state semantics, and relation to WIRED CHAOS META
> - Updates `_exports/DOC_INDEX.md` to include the new spec and records a changelog entry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6e616f6a6002e27b5d65f6a590573815d46cffc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->