### PR TITLE
Add WIRED CHAOS PR Prompt Codex documentation

### DIFF
--- a/docs/WIRED_CHAOS_PR_PROMPT_CODEX.md
+++ b/docs/WIRED_CHAOS_PR_PROMPT_CODEX.md
@@ -1,0 +1,101 @@
+# WIRED CHAOS PR Prompt Codex
+
+This prompt is an operational template for preparing clean, reviewable pull requests that respect system architecture, governance, and signal hygiene.
+
+---
+
+## Role
+You are acting as a senior systems engineer contributing to the WIRED CHAOS META ecosystem. Your task is to prepare a pull request that is legible to humans, agents, and future auditors.
+
+## Context Injection
+This PR exists within a multi-agent, MCP-driven architecture with strong separation between:
+- agents
+- patches
+- tools
+- governance
+- UI ink
+
+Assume the reader understands the system but did not author this change.
+
+## Intent Declaration
+Start by stating, in one paragraph:
+- what problem this PR solves
+- why the change is necessary now
+- what system pressure or friction it removes
+
+No hype. No future promises.
+
+## Scope Definition
+Explicitly list:
+- what this PR changes
+- what it intentionally does not change
+- which subsystems are touched (e.g. MCP, UI ink, agents, patches)
+
+If scope leaks, call it out.
+
+## Change Summary
+Describe the changes at a conceptual level before implementation details.
+Focus on:
+- behavior changes
+- integration points
+- removed complexity or risk
+
+Avoid restating the diff.
+
+## Technical Details
+Explain:
+- new abstractions or adapters introduced
+- config changes or new dependencies
+- why existing patterns were reused or avoided
+
+If a shortcut was taken, justify it.
+
+## Governance & Safety
+Answer explicitly:
+- does this expose new tools to agents
+- does it change permission boundaries
+- does it affect credential handling or proxies
+
+If the answer is “no,” say why.
+
+## Testing & Verification
+State:
+- how this was tested
+- what was manually verified
+- what is assumed but not yet validated
+
+No tests is acceptable if acknowledged.
+
+## Risk Assessment
+Briefly outline:
+- potential failure modes
+- rollback strategy
+- what signals would indicate breakage
+
+This is not fear — it’s professionalism.
+
+## Future Notes (Non-Binding)
+Optionally include:
+- follow-up work
+- known limitations
+- refactors deferred
+
+Label this clearly as non-blocking.
+
+---
+
+## How this helps WIRED CHAOS
+
+This codex does three things simultaneously:
+- trains contributors to think in system terms
+- reduces review entropy
+- creates PRs that agents can eventually parse and reason about
+
+It turns pull requests into structured artifacts, not narrative blobs.
+
+If you want, next we can:
+- tailor a version specifically for MCP / stitch-mcp integrations
+- generate a GitHub PR template file from this
+- adapt it into an agent-internal “self-review” prompt before commits
+
+Clean merges are how chaos scales without collapsing.


### PR DESCRIPTION
### Motivation
- Add a single, reviewable operational template that documents how to prepare structured PRs for the WIRED CHAOS META ecosystem to reduce review entropy and make PRs machine- and auditor-friendly.

### Description
- Introduces `docs/WIRED_CHAOS_PR_PROMPT_CODEX.md` containing the PR Prompt Codex and makes no changes to application logic, configuration, dependencies, or tooling.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6971835b07fc83279ec70636c7e9eea5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `docs/WIRED_CHAOS_PR_PROMPT_CODEX.md`, a structured guide for composing clear, auditable pull requests within the WIRED CHAOS multi-agent/MCP context.
> 
> - Defines sections for `Intent`, `Scope`, `Change Summary`, `Technical Details`, `Governance & Safety`, `Testing & Verification`, `Risk Assessment`, and `Future Notes`
> - Emphasizes separation across `agents`, `patches`, `tools`, `governance`, and `UI ink`
> - No changes to application logic, configuration, dependencies, or tooling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b60a46e8d2b833254542568d4e4423977ae260f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->