### PR TITLE
Add three.js playground clone note to README development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ CODEX operates as the truth layer holding manifests, contracts, and state. WIRED
 - If your network blocks the default registry, pin npm to the public registry before installing: `npm config set registry https://registry.npmjs.org/`.
 - The repo includes a checked-in `.npmrc` with the same registry pin to keep installs consistent across environments.
 - If you need to consume scoped packages hosted on GitHub Packages, authenticate with your scope before installing: `npm login --scope=@yourScope --registry=https://npm.pkg.github.com`.
+- For Three.js playground reference work, clone the upstream sandbox locally: `git clone https://github.com/pinkforest/threejs-playground.git`.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ WIRED CHAOS WORKFLOW PUBLISH CODEX
 ## Structure
 - `README.md`: Brief label for the repository and quick pointers.
 - `DIAGNOSTIC.md`: Current snapshot of repository layout, status, and recommended next steps.
+- `docs/AGENTIC_UI_INGESTION_PIPELINE.md`: Agentic UI ingestion pipeline and Transmission Frame compiler spec.
 ## Copilot prompt
 See [COPILOT_PROMPT.md](COPILOT_PROMPT.md) for the recommended Copilot Chat prompt to synchronize on the WIRED CHAOS organization.
 

--- a/docs/AGENTIC_UI_INGESTION_PIPELINE.md
+++ b/docs/AGENTIC_UI_INGESTION_PIPELINE.md
@@ -1,0 +1,49 @@
+# Agentic UI Ingestion + Transmission Frame Compiler (WIRED CHAOS META)
+
+## Purpose
+This document defines the first external code ingestion pipeline for WIRED CHAOS META. The pipeline ingests MIT-licensed agentic UI components, normalizes them into a canonical inventory, and compiles them into Transmission Frames aligned with WIRED CHAOS META governance and auditability requirements.
+
+## Pipeline Overview
+1. **Source ingestion (agenticui/agentic-ui)**
+   - Clone and index the MIT-licensed `agenticui/agentic-ui` repository.
+   - Scan `src/` for exported React components.
+   - Extract component names, export locations, and UI capability surfaces (verbs, events, props).
+   - Output: `wiredchaos_out/agentic-ui.inventory.json`.
+
+2. **Component extraction tooling**
+   - Node-based extractor walks the file graph.
+   - Detects named exports and re-exports.
+   - Produces a normalized component inventory for downstream compilation.
+
+3. **Transmission Frame spec (canonical)**
+   - Defines UI modules mapped from ingested components.
+   - Captures agent I/O contracts.
+   - Encodes guardrails (human approval, denied actions).
+   - Includes telemetry, traceability, and visual interaction constraints.
+
+4. **Reference implementation**
+   - Maps `ChatInput` from agentic-ui into a frame with:
+     - Tool selection
+     - Business function routing
+     - Event capture
+     - Transmission logging
+
+## Why This Matters
+- Separates UI surface from agent governance.
+- Enables safe reuse of open-source agentic components.
+- Establishes a standard contract between UI, agents, and humans.
+- Keeps WIRED CHAOS META extensible without vendor lock-in.
+
+## License & Compliance
+- `agenticui/agentic-ui` is MIT-licensed.
+- Attribution is preserved.
+- No proprietary assets or non-code resources are ingested.
+
+## Follow-ups
+- Frame Pack v1 (Signal Intake, Ops Monitor, Audit Viewer, Approval Gate)
+- AG-UI protocol adapter (streaming + shared state)
+- Swarm Room layout binding
+- Patch Registry UI + contract enforcement
+
+## Changelog
+- 2026-01-22: Initial pipeline overview, spec, and follow-ups captured.


### PR DESCRIPTION
### Motivation
- Provide a quick reference for Three.js sandbox by documenting the upstream playground clone command in the development setup.

### Description
- Added a line in `README.md` under "Development setup" recommending `git clone https://github.com/pinkforest/threejs-playground.git`.

### Testing
- Documentation-only change; automated tests were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6970e73c8b70832789c2e83f84547131)