### PR TITLE
Root Brain: Add PR Codex routing, validation, execution, and receipts

### DIFF
--- a/root/brain/pr-codex/audit-log.ts
+++ b/root/brain/pr-codex/audit-log.ts
@@ -1,0 +1,22 @@
+export type AuditEntry = {
+  timestamp: string;
+  pr_id: string;
+  action: string;
+  details: Record<string, unknown>;
+};
+
+export type AuditLogger = {
+  log: (entry: AuditEntry) => void;
+  entries: () => AuditEntry[];
+};
+
+export const createAuditLogger = (): AuditLogger => {
+  const logStore: AuditEntry[] = [];
+
+  return {
+    log: (entry) => {
+      logStore.push(entry);
+    },
+    entries: () => [...logStore],
+  };
+};

--- a/root/brain/pr-codex/executor-adapter.ts
+++ b/root/brain/pr-codex/executor-adapter.ts
@@ -1,0 +1,79 @@
+import type { PRObject } from './schema.js';
+import { routePR } from './router.js';
+
+export type PlanArtifact = {
+  type: 'plan';
+  steps: string[];
+  filesTouched: string[];
+  toolCalls: string[];
+  expectedOutputs: string[];
+};
+
+export type ChangeArtifact = {
+  type: 'change';
+  diffs: string[];
+  generatedArtifacts: string[];
+};
+
+export type TestArtifact = {
+  type: 'test';
+  checks: string[];
+  evidence: string[];
+};
+
+export type ReceiptArtifact = {
+  type: 'receipt';
+  pr_id: string;
+  routing: string[];
+  riskScore: number;
+  diffHash: string;
+};
+
+export type ExecutionArtifacts =
+  | PlanArtifact
+  | ChangeArtifact
+  | TestArtifact
+  | ReceiptArtifact;
+
+export type ExecutionResult = {
+  artifacts: ExecutionArtifacts[];
+};
+
+export const executePR = (pr: PRObject, riskScore: number): ExecutionResult => {
+  const routing = routePR(pr);
+
+  const plan: PlanArtifact = {
+    type: 'plan',
+    steps: [
+      'Normalize and validate PR object',
+      `Route PR to legs: ${routing.legs.join(', ')}`,
+      'Generate change plan and update artifacts',
+      'Record audit log entry',
+    ],
+    filesTouched: [],
+    toolCalls: [],
+    expectedOutputs: ['Plan Artifact', 'Change Artifact', 'Test Artifact', 'Receipt Artifact'],
+  };
+
+  const change: ChangeArtifact = {
+    type: 'change',
+    diffs: [],
+    generatedArtifacts: [],
+  };
+
+  const test: TestArtifact = {
+    type: 'test',
+    checks: pr.acceptance_tests,
+    evidence: [],
+  };
+
+  const receipt: ReceiptArtifact = {
+    type: 'receipt',
+    pr_id: pr.pr_id,
+    routing: routing.legs,
+    riskScore,
+    diffHash: '',
+  };
+
+  return { artifacts: [plan, change, test, receipt] };
+};

--- a/root/brain/pr-codex/index.ts
+++ b/root/brain/pr-codex/index.ts
@@ -1,0 +1,12 @@
+export { createPR, PRSchema } from './schema.js';
+export type { PRObject } from './schema.js';
+export { validatePR, assertValidPR } from './validate.js';
+export type { PRValidationResult } from './validate.js';
+export { routePR } from './router.js';
+export type { RoutingResult } from './router.js';
+export { executePR } from './executor-adapter.js';
+export type { ExecutionArtifacts, ExecutionResult } from './executor-adapter.js';
+export { createAuditLogger } from './audit-log.js';
+export type { AuditEntry, AuditLogger } from './audit-log.js';
+export { finalizePR, buildDiffHash } from './receipts.js';
+export type { PRReceipt } from './receipts.js';

--- a/root/brain/pr-codex/receipts.ts
+++ b/root/brain/pr-codex/receipts.ts
@@ -1,0 +1,36 @@
+import { createHash } from 'crypto';
+import type { PRObject } from './schema.js';
+import type { ExecutionArtifacts } from './executor-adapter.js';
+import { routePR } from './router.js';
+
+export type PRReceipt = {
+  pr_id: string;
+  routing: string[];
+  requiredReviews: string[];
+  riskScore: number;
+  diffHash: string;
+  approvalChain: string[];
+  initiatingIdentity: string;
+  subsystemScope: string;
+};
+
+export const buildDiffHash = (artifacts: ExecutionArtifacts[]): string => {
+  const payload = JSON.stringify(artifacts);
+  return createHash('sha256').update(payload).digest('hex');
+};
+
+export const finalizePR = (pr: PRObject, artifacts: ExecutionArtifacts[], riskScore: number): PRReceipt => {
+  const routing = routePR(pr);
+  const diffHash = buildDiffHash(artifacts);
+
+  return {
+    pr_id: pr.pr_id,
+    routing: routing.legs,
+    requiredReviews: routing.requiredReviews,
+    riskScore,
+    diffHash,
+    approvalChain: routing.requiredReviews,
+    initiatingIdentity: pr.owner,
+    subsystemScope: pr.target.subsystem,
+  };
+};

--- a/root/brain/pr-codex/router.ts
+++ b/root/brain/pr-codex/router.ts
@@ -1,0 +1,60 @@
+import type { PRObject } from './schema.js';
+
+export type RoutingResult = {
+  legs: string[];
+  agents: string[];
+  requiredReviews: string[];
+  safeguards: string[];
+};
+
+const legMap = new Map<string, string>([
+  ['remotion', 'LEG:MOTION_FORGE'],
+  ['frontend', 'LEG:VISION_STRUCT'],
+  ['backend', 'LEG:SWARM_COORD'],
+  ['prompts', 'LEG:AKASHIC_ENGINE'],
+  ['infra', 'LEG:SWARM_COORD'],
+  ['docs', 'LEG:SWARM_COORD'],
+]);
+
+export const routePR = (pr: PRObject): RoutingResult => {
+  const legs = new Set<string>();
+  const requiredReviews = new Set<string>();
+  const safeguards = new Set<string>();
+
+  const surfaceLeg = legMap.get(pr.target.surface);
+  if (surfaceLeg) {
+    legs.add(surfaceLeg);
+  }
+
+  if (pr.target.subsystem === 'TAX_SUITE' || pr.target.subsystem === 'TRUST_SUITE') {
+    legs.add('LEG:TAX_TRUST');
+  }
+
+  if (pr.target.subsystem === 'AKIRA_CODEX' || pr.target.subsystem === 'NPC') {
+    legs.add('LEG:AKASHIC_ENGINE');
+  }
+
+  if (pr.target.subsystem === 'FEN') {
+    legs.add('LEG:FEN_ENGINE');
+  }
+
+  const isHighRisk = pr.risk.user_impact === 'high' || pr.risk.data_access === 'high';
+  if (isHighRisk) {
+    requiredReviews.add('LEG:ANTI_MOLOCH');
+    safeguards.add('explicit sandbox execution');
+    safeguards.add('diff summary required');
+    safeguards.add('test evidence required');
+    safeguards.add('rollback plan present');
+  }
+
+  if (pr.change_type === 'security') {
+    requiredReviews.add('LEG:ANTI_MOLOCH');
+  }
+
+  return {
+    legs: Array.from(legs),
+    agents: Array.from(legs),
+    requiredReviews: Array.from(requiredReviews),
+    safeguards: Array.from(safeguards),
+  };
+};

--- a/root/brain/pr-codex/schema.ts
+++ b/root/brain/pr-codex/schema.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+
+export const SubsystemEnum = z.enum([
+  'CHAOS_OS',
+  'NPC',
+  'AKIRA_CODEX',
+  'CREATOR_CODEX',
+  'FEN',
+  'TAX_SUITE',
+  'TRUST_SUITE',
+  'OTHER',
+]);
+
+export const SurfaceEnum = z.enum([
+  'backend',
+  'frontend',
+  'prompts',
+  'remotion',
+  'infra',
+  'docs',
+]);
+
+export const ChangeTypeEnum = z.enum([
+  'feature',
+  'fix',
+  'refactor',
+  'integration',
+  'security',
+  'performance',
+  'content',
+]);
+
+export const RiskLevelEnum = z.enum(['none', 'low', 'medium', 'high']);
+export const BlastRadiusEnum = z.enum([
+  'single_module',
+  'subsystem',
+  'multi_subsystem',
+]);
+
+export const PRSchema = z.object({
+  pr_id: z.string().regex(/^WC-PR-\d{8}-\d{4}$/),
+  title: z.string().min(1),
+  intent: z.string().min(1),
+  target: z.object({
+    subsystem: SubsystemEnum,
+    module: z.string().min(1),
+    surface: SurfaceEnum,
+  }),
+  change_type: ChangeTypeEnum,
+  constraints: z.object({
+    must_not: z.array(z.string()).default([]),
+    must: z.array(z.string()).default([]),
+    style: z.array(z.string()).default([]),
+    security: z.array(z.string()).default([]),
+  }),
+  inputs: z
+    .object({
+      links: z.array(z.string()).default([]),
+      files: z.array(z.string()).default([]),
+      context_artifacts: z.array(z.string()).default([]),
+    })
+    .optional()
+    .default({ links: [], files: [], context_artifacts: [] }),
+  acceptance_tests: z.array(z.string()).min(1),
+  risk: z.object({
+    data_access: RiskLevelEnum,
+    blast_radius: BlastRadiusEnum,
+    user_impact: RiskLevelEnum,
+  }),
+  deliverables: z.array(z.string()).min(1),
+  rollback_plan: z.string().optional(),
+  owner: z.string().min(1),
+  timestamp: z.string().datetime(),
+});
+
+export type PRObject = z.infer<typeof PRSchema>;
+
+export const createPR = (input: unknown): PRObject => {
+  return PRSchema.parse(input);
+};

--- a/root/brain/pr-codex/tests/pr-codex.test.ts
+++ b/root/brain/pr-codex/tests/pr-codex.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { createPR, executePR, finalizePR, routePR, validatePR } from '../index.js';
+
+const basePR = createPR({
+  pr_id: 'WC-PR-20250101-0001',
+  title: 'Add UI-Context Artifact capture to VisionStruct',
+  intent: 'Enable element targeting via selector capture.',
+  target: {
+    subsystem: 'CREATOR_CODEX',
+    module: 'inspector-overlay',
+    surface: 'frontend',
+  },
+  change_type: 'feature',
+  constraints: {
+    must_not: ['log secrets'],
+    must: ['emit receipt artifact'],
+    style: ['camelCase'],
+    security: ['least privilege'],
+  },
+  inputs: {
+    links: [],
+    files: [],
+    context_artifacts: [],
+  },
+  acceptance_tests: ['Given a UI node, when captured, then selectors are exported'],
+  risk: {
+    data_access: 'low',
+    blast_radius: 'single_module',
+    user_impact: 'low',
+  },
+  deliverables: ['code diff', 'docs update'],
+  rollback_plan: '',
+  owner: 'NEURO',
+  timestamp: '2025-01-01T00:00:00.000Z',
+});
+
+const validation = validatePR(basePR);
+assert.equal(validation.ok, true);
+
+const routing = routePR(basePR);
+assert.ok(routing.legs.includes('LEG:VISION_STRUCT'));
+
+const execution = executePR(basePR, validation.riskScore);
+assert.equal(execution.artifacts.length, 4);
+
+const receipt = finalizePR(basePR, execution.artifacts, validation.riskScore);
+assert.ok(receipt.diffHash.length > 0);

--- a/root/brain/pr-codex/validate.ts
+++ b/root/brain/pr-codex/validate.ts
@@ -1,0 +1,51 @@
+import type { PRObject } from './schema.js';
+import { PRSchema } from './schema.js';
+
+export type PRValidationResult = {
+  ok: boolean;
+  errors: string[];
+  riskScore: number;
+};
+
+const riskWeights: Record<string, number> = {
+  none: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+};
+
+const blastWeights: Record<string, number> = {
+  single_module: 1,
+  subsystem: 2,
+  multi_subsystem: 3,
+};
+
+export const validatePR = (input: unknown): PRValidationResult => {
+  const parsed = PRSchema.safeParse(input);
+  const errors: string[] = [];
+
+  if (!parsed.success) {
+    parsed.error.issues.forEach((issue) => {
+      const path = issue.path.join('.') || 'root';
+      errors.push(`${path}: ${issue.message}`);
+    });
+    return { ok: false, errors, riskScore: 0 };
+  }
+
+  const pr = parsed.data;
+
+  if (pr.risk.blast_radius !== 'single_module' && !pr.rollback_plan) {
+    errors.push('rollback_plan: required when blast_radius is not single_module');
+  }
+
+  const riskScore =
+    riskWeights[pr.risk.data_access] +
+    riskWeights[pr.risk.user_impact] +
+    blastWeights[pr.risk.blast_radius];
+
+  return { ok: errors.length === 0, errors, riskScore };
+};
+
+export const assertValidPR = (pr: PRObject): PRValidationResult => {
+  return validatePR(pr);
+};


### PR DESCRIPTION
### Motivation
- Provide a standardized PR intake, validation, routing, execution, and audit pipeline for the Root Brain to turn ad-hoc change requests into verifiable, routable artifacts.
- Enforce safety rails like risk scoring and rollback-plan requirements to gate higher-risk changes deterministically.
- Enable deterministic routing to patch legs/agents so PRs are sent to the correct subsystem/toolchain.

### Description
- Add a canonical schema with `zod` in `root/brain/pr-codex/schema.ts` and a `createPR` helper to normalize PR objects. 
- Implement validation and risk scoring in `root/brain/pr-codex/validate.ts` that enforces `rollback_plan` when `blast_radius` ≠ `single_module` and computes a numeric `riskScore`.
- Implement deterministic routing in `root/brain/pr-codex/router.ts` mapping surfaces/subsystems to legs (e.g. `remotion`→`LEG:MOTION_FORGE`, `frontend`→`LEG:VISION_STRUCT`) and automatically adding `LEG:ANTI_MOLOCH` and safeguards for high-risk or `security` PRs.
- Provide an executor scaffolding in `root/brain/pr-codex/executor-adapter.ts` that produces `Plan`, `Change`, `Test`, and `Receipt` artifacts, plus an audit logger in `root/brain/pr-codex/audit-log.ts`.
- Add receipt generation and diff hashing via `buildDiffHash` and `finalizePR` in `root/brain/pr-codex/receipts.ts` which returns a `PRReceipt` including routing, required reviews, `riskScore`, and a `sha256` diff hash.
- Export module surface in `root/brain/pr-codex/index.ts` and add a baseline test fixture at `root/brain/pr-codex/tests/pr-codex.test.ts` that asserts validation, routing, artifact emission, and receipt hashing.

### Testing
- A baseline test file `root/brain/pr-codex/tests/pr-codex.test.ts` was added that constructs a sample PR and asserts `validatePR`, `routePR`, `executePR` return expected artifacts, and `finalizePR` produces a non-empty `diffHash`.
- No automated test runner was executed as part of this change (tests were added but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6972bee9fb7c8327a5812aedadf78a0b)