### PR TITLE
Add SOTD editorial experience with offscreen WebGPU renderer

### DIFF
--- a/app/_components/SotdExperience.tsx
+++ b/app/_components/SotdExperience.tsx
@@ -1,0 +1,254 @@
+"use client"
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { ArrowUpRight } from "lucide-react"
+
+const mirrorSelector = "[data-3d-mirror]"
+
+type MirrorRect = {
+  id: string
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export default function SotdExperience() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const workerRef = useRef<Worker | null>(null)
+  const rafRef = useRef<number | null>(null)
+  const [offscreenSupported, setOffscreenSupported] = useState(true)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    if (!canvas.transferControlToOffscreen) {
+      setOffscreenSupported(false)
+      return
+    }
+
+    const worker = new Worker(new URL("../_workers/sotd-renderer.ts", import.meta.url), {
+      type: "module",
+    })
+    workerRef.current = worker
+
+    const offscreen = canvas.transferControlToOffscreen()
+    const size = { width: window.innerWidth, height: window.innerHeight }
+    worker.postMessage(
+      {
+        type: "init",
+        canvas: offscreen,
+        size,
+        dpr: window.devicePixelRatio ?? 1,
+      },
+      [offscreen]
+    )
+
+    const handleResize = () => {
+      worker.postMessage({
+        type: "resize",
+        size: { width: window.innerWidth, height: window.innerHeight },
+        dpr: window.devicePixelRatio ?? 1,
+      })
+    }
+
+    window.addEventListener("resize", handleResize)
+
+    return () => {
+      window.removeEventListener("resize", handleResize)
+      worker.terminate()
+      workerRef.current = null
+    }
+  }, [])
+
+  useLayoutEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const sendLayout = () => {
+      const elements = Array.from(container.querySelectorAll<HTMLElement>(mirrorSelector))
+      const rects: MirrorRect[] = elements.map((element, index) => {
+        const rect = element.getBoundingClientRect()
+        return {
+          id: element.dataset.mirrorId ?? `mirror-${index}`,
+          x: rect.left,
+          y: rect.top,
+          width: rect.width,
+          height: rect.height,
+        }
+      })
+
+      workerRef.current?.postMessage({
+        type: "layout",
+        rects,
+        size: { width: window.innerWidth, height: window.innerHeight },
+      })
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      if (rafRef.current !== null) return
+      rafRef.current = window.requestAnimationFrame(() => {
+        sendLayout()
+        rafRef.current = null
+      })
+    })
+
+    const elements = Array.from(container.querySelectorAll<HTMLElement>(mirrorSelector))
+    elements.forEach((element) => resizeObserver.observe(element))
+
+    const handleScroll = () => {
+      if (rafRef.current !== null) return
+      rafRef.current = window.requestAnimationFrame(() => {
+        const scrollTop = window.scrollY
+        const scrollRange = document.body.scrollHeight - window.innerHeight
+        const progress = scrollRange > 0 ? scrollTop / scrollRange : 0
+        workerRef.current?.postMessage({ type: "scroll", progress })
+        sendLayout()
+        rafRef.current = null
+      })
+    }
+
+    window.addEventListener("scroll", handleScroll, { passive: true })
+    window.addEventListener("resize", sendLayout)
+    sendLayout()
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll)
+      window.removeEventListener("resize", sendLayout)
+      resizeObserver.disconnect()
+      if (rafRef.current !== null) {
+        window.cancelAnimationFrame(rafRef.current)
+      }
+    }
+  }, [])
+
+  return (
+    <div ref={containerRef} className="relative min-h-screen bg-[#0b0b0c] text-white">
+      <canvas
+        ref={canvasRef}
+        className="pointer-events-none fixed inset-0 h-full w-full"
+        aria-hidden
+      />
+
+      {!offscreenSupported && (
+        <div className="fixed inset-x-0 top-20 z-30 mx-auto flex max-w-md items-center justify-center rounded-full border border-white/10 bg-black/70 px-4 py-2 text-xs uppercase tracking-[0.3em] text-white/70">
+          OffscreenCanvas unavailable — 3D accents paused.
+        </div>
+      )}
+
+      <header className="relative z-10 border-b border-white/10 bg-black/20 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-5 text-xs uppercase tracking-[0.35em] text-white/70">
+          <span>Three.js Blocks</span>
+          <span>Edition 2025</span>
+        </div>
+      </header>
+
+      <main className="relative z-10">
+        <section className="mx-auto flex min-h-[90vh] max-w-6xl flex-col justify-center gap-8 px-6 py-24">
+          <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.3em] text-white/60">
+            <span className="h-[1px] w-12 bg-white/40" data-3d-mirror data-mirror-id="hero-line" />
+            <span>Editorial Systems</span>
+          </div>
+          <h1
+            className="max-w-4xl text-4xl font-light leading-tight tracking-tight text-white sm:text-6xl"
+            data-3d-mirror
+            data-mirror-id="hero-title"
+          >
+            A minimal, editorial space where text stays crisp and 3D stays restrained.
+          </h1>
+          <p className="max-w-2xl text-base leading-relaxed text-white/70" data-3d-mirror data-mirror-id="hero-copy">
+            WebGPU-first, offscreen-rendered accents synchronize with the DOM to deliver calm, premium motion without
+            layout shifts.
+          </p>
+          <div className="flex flex-wrap items-center gap-6 text-sm uppercase tracking-[0.2em] text-white/60">
+            <button className="flex items-center gap-2 border-b border-white/50 pb-1 text-white">
+              Enter the build <ArrowUpRight className="h-4 w-4" />
+            </button>
+            <span>Scroll to calibrate</span>
+          </div>
+        </section>
+
+        <section className="mx-auto grid min-h-[85vh] max-w-6xl grid-cols-1 gap-12 px-6 py-24 md:grid-cols-[1.1fr_0.9fr]">
+          <div className="space-y-6">
+            <p className="text-xs uppercase tracking-[0.4em] text-white/60">Craft Notes</p>
+            <h2
+              className="text-3xl font-light leading-snug text-white sm:text-4xl"
+              data-3d-mirror
+              data-mirror-id="section-title"
+            >
+              Blocks orchestrate UI and rendering into a single, predictable rhythm.
+            </h2>
+            <p className="text-base leading-relaxed text-white/70" data-3d-mirror data-mirror-id="section-copy">
+              Each component owns its DOM signature, while the worker thread mirrors that geometry into soft light and
+              depth. Scroll transitions remain GPU-friendly and measured.
+            </p>
+          </div>
+          <div className="space-y-6 text-sm text-white/70">
+            <div className="flex items-center justify-between border-b border-white/10 pb-4">
+              <span>WebGPU primary</span>
+              <span className="text-white">✓</span>
+            </div>
+            <div className="flex items-center justify-between border-b border-white/10 pb-4">
+              <span>WebGL fallback</span>
+              <span className="text-white">✓</span>
+            </div>
+            <div className="flex items-center justify-between border-b border-white/10 pb-4">
+              <span>OffscreenCanvas</span>
+              <span className="text-white">✓</span>
+            </div>
+            <div className="flex items-center justify-between border-b border-white/10 pb-4">
+              <span>DOM mirrored to 3D</span>
+              <span className="text-white">✓</span>
+            </div>
+            <div className="flex items-center justify-between border-b border-white/10 pb-4">
+              <span>Zero layout shift</span>
+              <span className="text-white">✓</span>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto flex min-h-[75vh] max-w-6xl flex-col justify-center gap-10 px-6 py-24">
+          <div className="flex items-center justify-between text-xs uppercase tracking-[0.4em] text-white/60">
+            <span>Scroll-driven transitions</span>
+            <span>03</span>
+          </div>
+          <div className="grid gap-10 md:grid-cols-3">
+            {[
+              {
+                title: "Hero sync",
+                copy: "Typography leads. 3D accents glide beneath, aligned to DOM geometry for clarity.",
+              },
+              {
+                title: "Editorial pacing",
+                copy: "Measured motion anchors attention and allows negative space to breathe.",
+              },
+              {
+                title: "Calm resolution",
+                copy: "The footer settles into a resolved state with minimal drift.",
+              },
+            ].map((item) => (
+              <div key={item.title} className="space-y-3 border-t border-white/10 pt-6">
+                <h3 className="text-base uppercase tracking-[0.3em] text-white" data-3d-mirror data-mirror-id={item.title}>
+                  {item.title}
+                </h3>
+                <p className="text-sm leading-relaxed text-white/70">{item.copy}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </main>
+
+      <footer className="relative z-10 border-t border-white/10 bg-black/30">
+        <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-12 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.35em] text-white/60">Resolution</p>
+            <p className="mt-3 text-lg font-light text-white">A calm state for the final motion.</p>
+          </div>
+          <div className="text-xs uppercase tracking-[0.35em] text-white/60">SOTD-ready • 2025</div>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/app/_workers/sotd-renderer.ts
+++ b/app/_workers/sotd-renderer.ts
@@ -1,0 +1,182 @@
+/// <reference lib="webworker" />
+
+import * as THREE from "three"
+import { WebGPURenderer } from "three/webgpu"
+
+type InitMessage = {
+  type: "init"
+  canvas: OffscreenCanvas
+  size: { width: number; height: number }
+  dpr: number
+}
+
+type ResizeMessage = {
+  type: "resize"
+  size: { width: number; height: number }
+  dpr: number
+}
+
+type LayoutMessage = {
+  type: "layout"
+  rects: Array<{ id: string; x: number; y: number; width: number; height: number }>
+  size: { width: number; height: number }
+}
+
+type ScrollMessage = {
+  type: "scroll"
+  progress: number
+}
+
+type IncomingMessage = InitMessage | ResizeMessage | LayoutMessage | ScrollMessage
+
+let renderer: THREE.Renderer | null = null
+let scene: THREE.Scene | null = null
+let camera: THREE.OrthographicCamera | null = null
+let accentGroup: THREE.Group | null = null
+let scrollProgress = 0
+let clock: THREE.Clock | null = null
+const mirrorMeshes = new Map<string, THREE.Mesh>()
+
+const ensureScene = () => {
+  if (!scene) {
+    scene = new THREE.Scene()
+  }
+  if (!clock) {
+    clock = new THREE.Clock()
+  }
+  if (!accentGroup) {
+    accentGroup = new THREE.Group()
+    scene.add(accentGroup)
+  }
+}
+
+const updateCamera = (width: number, height: number) => {
+  if (!camera) {
+    camera = new THREE.OrthographicCamera(-width / 2, width / 2, height / 2, -height / 2, -500, 1000)
+    camera.position.set(0, 0, 500)
+    camera.lookAt(0, 0, 0)
+  } else {
+    camera.left = -width / 2
+    camera.right = width / 2
+    camera.top = height / 2
+    camera.bottom = -height / 2
+    camera.updateProjectionMatrix()
+  }
+}
+
+const setSize = (width: number, height: number, dpr: number) => {
+  if (!renderer) return
+  updateCamera(width, height)
+  renderer.setSize(width, height, false)
+  if ("setPixelRatio" in renderer) {
+    ;(renderer as THREE.WebGLRenderer).setPixelRatio(dpr)
+  }
+}
+
+const initRenderer = async (canvas: OffscreenCanvas, width: number, height: number, dpr: number) => {
+  ensureScene()
+
+  if ("gpu" in self.navigator) {
+    const webgpuRenderer = new WebGPURenderer({ canvas, antialias: true, alpha: true })
+    await webgpuRenderer.init()
+    renderer = webgpuRenderer
+  } else {
+    renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true })
+  }
+
+  renderer.setClearColor(0x000000, 0)
+  setSize(width, height, dpr)
+
+  const ambient = new THREE.AmbientLight(0xffffff, 0.5)
+  const key = new THREE.DirectionalLight(0xffffff, 0.6)
+  key.position.set(0, 0, 300)
+  const fill = new THREE.DirectionalLight(0x6677ff, 0.3)
+  fill.position.set(200, 100, 150)
+  scene?.add(ambient, key, fill)
+
+  const backdrop = new THREE.Mesh(
+    new THREE.PlaneGeometry(2000, 2000),
+    new THREE.MeshBasicMaterial({ color: 0x0b0b0c, transparent: true, opacity: 0.6 })
+  )
+  backdrop.position.z = -300
+  scene?.add(backdrop)
+
+  renderer.setAnimationLoop(() => renderFrame())
+}
+
+const syncMirrors = (rects: LayoutMessage["rects"], viewport: { width: number; height: number }) => {
+  if (!accentGroup) return
+
+  rects.forEach((rect, index) => {
+    const existing = mirrorMeshes.get(rect.id)
+    const depth = -50 - index * 8
+    const centerX = rect.x + rect.width / 2 - viewport.width / 2
+    const centerY = -(rect.y + rect.height / 2 - viewport.height / 2)
+
+    if (existing) {
+      if (existing.geometry instanceof THREE.PlaneGeometry) {
+        existing.geometry.dispose()
+        existing.geometry = new THREE.PlaneGeometry(rect.width, rect.height)
+      }
+      existing.position.set(centerX, centerY, depth)
+      existing.userData.depth = depth
+      return
+    }
+
+    const geometry = new THREE.PlaneGeometry(rect.width, rect.height)
+    const material = new THREE.MeshStandardMaterial({
+      color: 0xffffff,
+      transparent: true,
+      opacity: 0.08,
+      metalness: 0.2,
+      roughness: 0.1,
+    })
+    const mesh = new THREE.Mesh(geometry, material)
+    mesh.position.set(centerX, centerY, depth)
+    mesh.userData.depth = depth
+    accentGroup?.add(mesh)
+    mirrorMeshes.set(rect.id, mesh)
+  })
+}
+
+const renderFrame = () => {
+  if (!renderer || !scene || !camera || !accentGroup || !clock) return
+
+  const elapsed = clock.getElapsedTime()
+  accentGroup.rotation.z = scrollProgress * 0.08
+
+  mirrorMeshes.forEach((mesh, index) => {
+    const baseDepth = mesh.userData.depth ?? 0
+    mesh.position.z = baseDepth + Math.sin(elapsed * 0.6 + index) * 6 + scrollProgress * 40
+    mesh.rotation.x = Math.sin(elapsed * 0.4 + index) * 0.02
+    mesh.rotation.y = Math.cos(elapsed * 0.3 + index) * 0.02
+  })
+
+  renderer.render(scene, camera)
+}
+
+self.onmessage = (event: MessageEvent<IncomingMessage>) => {
+  const message = event.data
+
+  if (message.type === "init") {
+    void initRenderer(message.canvas, message.size.width, message.size.height, message.dpr)
+    return
+  }
+
+  if (message.type === "resize") {
+    setSize(message.size.width, message.size.height, message.dpr)
+    return
+  }
+
+  if (message.type === "layout") {
+    updateCamera(message.size.width, message.size.height)
+    syncMirrors(message.rects, message.size)
+    return
+  }
+
+  if (message.type === "scroll") {
+    scrollProgress = message.progress
+  }
+}
+
+export {}

--- a/app/globals.css
+++ b/app/globals.css
@@ -164,13 +164,13 @@
 
 body {
   margin: 0;
-  font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-  background: #000000;
-  color: #00ffff;
+  font-family: var(--font-app-sans), "Inter", system-ui, sans-serif;
+  background: #0b0b0c;
+  color: #f5f5f5;
 }
 
 a {
-  color: #00ffff;
+  color: inherit;
   text-decoration: none;
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,8 +7,8 @@ const appSans = Inter({ subsets: ["latin"], variable: "--font-app-sans" })
 const appMono = JetBrains_Mono({ subsets: ["latin"], variable: "--font-app-mono" })
 
 export const metadata: Metadata = {
-  title: "WIRED CHAOS META HUB | Galaxy Orchestrator",
-  description: "Trinity 3D navigation hub for isolated patch architecture across Business and Akashic realms",
+  title: "Blocks SOTD — Editorial WebGPU Experience",
+  description: "Minimalist, editorial SOTD concept built on Three.js Blocks with WebGPU-first rendering.",
   generator: "v0.app",
   icons: {
     icon: [

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,7 @@
-import nextDynamic from "next/dynamic"
-
-// Prevent server-side evaluation of WebGL / R3F modules.
-const GalaxyHubClient = nextDynamic(() => import("./_components/GalaxyHubClient"), { ssr: false })
+import SotdExperience from "./_components/SotdExperience"
 
 export const dynamic = "force-dynamic"
 
 export default function Page() {
-  return <GalaxyHubClient />
+  return <SotdExperience />
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,21 +8,39 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
-    "paths": { "@/*": ["./*"] },
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
     "plugins": [
       {
         "name": "next"
       }
     ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
### Motivation
- Provide a Three.js Blocks–style SOTD landing experience with a WebGPU-first, WebGL-fallback architecture and OffscreenCanvas-based rendering.
- Maintain perfect DOM ↔ 3D synchronization so typography remains selectable and accessible while 3D accents enhance hierarchy.
- Keep rendering off the main thread to avoid layout shifts and reduce main-thread work for high-performance inspection in DevTools.

### Description
- Added a client component `app/_components/SotdExperience.tsx` that scaffolds a minimalist editorial SOTD layout and posts DOM layout/scroll messages to a worker via OffscreenCanvas using `data-3d-mirror` hooks. 
- Implemented the worker renderer `app/_workers/sotd-renderer.ts` which prefers `WebGPURenderer` (`three/webgpu`) and falls back to `THREE.WebGLRenderer`, mirrors DOM geometry into soft 3D planes, and drives scroll-based motion in a dedicated thread. 
- Replaced the previous landing payload in `app/page.tsx` to mount the new `SotdExperience` client component and updated `app/layout.tsx` metadata to match the Blocks SOTD experience. 
- Updated global styling in `app/globals.css` to the editorial palette and adjusted TypeScript/Next dev config (`tsconfig.json`, `next-env.d.ts`) that were refreshed by the dev server for local dev ergonomics. 
- Minor renderer cleanup: removed an unused size state and fixed the WebGPU import path to `three/webgpu` for compatibility with the installed `three` package. 

### Testing
- Dev server run: started with `npm run dev -- --hostname 0.0.0.0 --port 3000` and the Next dev server reported "Ready" and served the app (dev compile completed and `GET / 200`). (Succeeded)
- End-to-end screenshot: a headless Playwright run using WebKit produced a full-page screenshot artifact (`artifacts/sotd-home.png`) to verify initial render and layout sync. (Succeeded)
- Chromium Playwright run crashed/timed out in the CI-like environment (headless Chromium SIGSEGV / TargetClosedError) and therefore did not produce a screenshot. (Failed)
- Runtime/compile notes: Next logged warnings about Google Fonts fetch (blocked in this environment) but compilation errors related to the WebGPU import were resolved by switching to `three/webgpu`. (Observations only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697372ee6de08327ba84a137e0d9422a)