### PR TITLE
Add headless WebGPU compute cell with buffer helpers, swarm kernel, and Legs wrapper

### DIFF
--- a/docs/WIRED_CHAOS_WEBGPU_COMPUTE_CELL.md
+++ b/docs/WIRED_CHAOS_WEBGPU_COMPUTE_CELL.md
@@ -1,0 +1,67 @@
+# WIRED CHAOS WebGPU Compute Cell
+
+This module is the headless WebGPU compute primitive for WIRED CHAOS. It is **not** a renderer, does **not** require a canvas, and is meant to live beneath Legs as a callable compute engine.
+
+## Integration stance
+
+- **Brain** stays unaware of WebGPU.
+- **Crab** can request high-throughput computations.
+- **Legs** owns the compute capability and calls the cell.
+
+## Compute cell API
+
+`WebGPUComputeCell.submit` is the only primitive you need:
+
+```
+submit({
+  inputBuffers,
+  outputByteLengths,
+  shader,
+  uniforms,
+  workgroupCount,
+}) → { outputBuffers }
+```
+
+### Binding layout contract
+
+Bindings are deterministic, so the shader stays predictable:
+
+1. `@group(0) @binding(0..N-1)` → input storage buffers (read-only)
+2. `@group(0) @binding(N..N+M-1)` → output storage buffers (read-write)
+3. `@group(0) @binding(N+M)` → uniform buffer (optional)
+
+If uniforms are omitted, the uniform binding is not created.
+
+## Example: swarm scoring kernel
+
+The included kernel scores agent state in parallel (non-visual). It treats each agent as four floats: `position.xy` + `velocity.xy`.
+
+```
+import { WebGPUComputeCell, buildSwarmScoreSubmission } from "src/lib/webgpu"
+
+const cell = await WebGPUComputeCell.create()
+const agents = new Float32Array(agentCount * 4)
+const submission = buildSwarmScoreSubmission(agents, agentCount, {
+  positionWeight: 1.2,
+  velocityWeight: 0.4,
+})
+
+const { outputBuffers } = await cell.submit(submission)
+const scores = new Float32Array(outputBuffers[0])
+```
+
+## Legs capability surface
+
+Use the Legs wrapper to keep the Brain blind to WebGPU:
+
+```
+import { createWebGPUComputeCell } from "src/lib/legs"
+
+const cell = await createWebGPUComputeCell()
+```
+
+## Operational notes
+
+- Prefer batch submissions over frame-by-frame readbacks.
+- Keep shader logic strictly numeric; do **not** embed agent logic in WGSL.
+- Use the buffer helpers in `src/lib/webgpu/buffers.ts` for alignment and safe IO.

--- a/src/lib/legs/index.ts
+++ b/src/lib/legs/index.ts
@@ -1,0 +1,1 @@
+export { createWebGPUComputeCell } from "./webgpuComputeCell"

--- a/src/lib/legs/webgpuComputeCell.ts
+++ b/src/lib/legs/webgpuComputeCell.ts
@@ -1,0 +1,5 @@
+import { WebGPUComputeCell } from "../webgpu"
+
+export async function createWebGPUComputeCell(): Promise<WebGPUComputeCell> {
+  return WebGPUComputeCell.create()
+}

--- a/src/lib/webgpu/buffers.ts
+++ b/src/lib/webgpu/buffers.ts
@@ -1,0 +1,71 @@
+export const UNIFORM_ALIGNMENT = 256
+
+export function alignTo(value: number, alignment: number = UNIFORM_ALIGNMENT): number {
+  return Math.ceil(value / alignment) * alignment
+}
+
+export function createStorageBuffer(
+  device: GPUDevice,
+  data: ArrayBufferView,
+  options: { label?: string; usage?: GPUBufferUsageFlags } = {},
+): GPUBuffer {
+  const usage = options.usage ?? (GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST)
+  const buffer = device.createBuffer({
+    label: options.label,
+    size: data.byteLength,
+    usage,
+    mappedAtCreation: true,
+  })
+  const mapped = buffer.getMappedRange()
+  new Uint8Array(mapped).set(new Uint8Array(data.buffer, data.byteOffset, data.byteLength))
+  buffer.unmap()
+  return buffer
+}
+
+export function createEmptyStorageBuffer(
+  device: GPUDevice,
+  byteLength: number,
+  options: { label?: string; usage?: GPUBufferUsageFlags } = {},
+): GPUBuffer {
+  const usage = options.usage ?? (GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC)
+  return device.createBuffer({
+    label: options.label,
+    size: byteLength,
+    usage,
+  })
+}
+
+export function createUniformBuffer(
+  device: GPUDevice,
+  data: ArrayBufferView,
+  options: { label?: string } = {},
+): GPUBuffer {
+  const size = alignTo(data.byteLength)
+  const buffer = device.createBuffer({
+    label: options.label,
+    size,
+    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+  })
+  device.queue.writeBuffer(buffer, 0, data.buffer, data.byteOffset, data.byteLength)
+  return buffer
+}
+
+export async function readBuffer(
+  device: GPUDevice,
+  buffer: GPUBuffer,
+  byteLength: number,
+): Promise<ArrayBuffer> {
+  const readback = device.createBuffer({
+    size: byteLength,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  })
+  const encoder = device.createCommandEncoder()
+  encoder.copyBufferToBuffer(buffer, 0, readback, 0, byteLength)
+  device.queue.submit([encoder.finish()])
+  await readback.mapAsync(GPUMapMode.READ)
+  const mapped = readback.getMappedRange()
+  const copy = mapped.slice(0)
+  readback.unmap()
+  readback.destroy()
+  return copy
+}

--- a/src/lib/webgpu/computeCell.ts
+++ b/src/lib/webgpu/computeCell.ts
@@ -1,0 +1,135 @@
+import {
+  createEmptyStorageBuffer,
+  createStorageBuffer,
+  createUniformBuffer,
+  readBuffer,
+} from "./buffers"
+
+export type ComputeSubmission = {
+  inputBuffers: ArrayBufferView[]
+  outputByteLengths: number[]
+  shader: string
+  uniforms?: ArrayBufferView
+  workgroupCount: [number, number, number]
+  entryPoint?: string
+  label?: string
+}
+
+export type ComputeResult = {
+  outputBuffers: ArrayBuffer[]
+}
+
+export class WebGPUComputeCell {
+  private pipelineCache = new Map<string, GPUComputePipeline>()
+
+  constructor(private readonly device: GPUDevice) {}
+
+  static async create(): Promise<WebGPUComputeCell> {
+    if (typeof navigator === "undefined" || !navigator.gpu) {
+      throw new Error("WebGPU is not available in this runtime.")
+    }
+
+    const adapter = await navigator.gpu.requestAdapter()
+    if (!adapter) {
+      throw new Error("WebGPU adapter not available.")
+    }
+
+    const device = await adapter.requestDevice()
+    return new WebGPUComputeCell(device)
+  }
+
+  async submit(submission: ComputeSubmission): Promise<ComputeResult> {
+    const {
+      inputBuffers,
+      outputByteLengths,
+      shader,
+      uniforms,
+      workgroupCount,
+      entryPoint = "main",
+      label,
+    } = submission
+
+    const bindGroupEntries: GPUBindGroupEntry[] = []
+    const layoutEntries: GPUBindGroupLayoutEntry[] = []
+
+    const inputStorageBuffers = inputBuffers.map((input, index) => {
+      const buffer = createStorageBuffer(this.device, input, {
+        label: `${label ?? "compute"}-input-${index}`,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+      })
+      bindGroupEntries.push({ binding: index, resource: { buffer } })
+      layoutEntries.push({
+        binding: index,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: { type: "read-only-storage" },
+      })
+      return buffer
+    })
+
+    const outputOffset = inputStorageBuffers.length
+    const outputBuffers = outputByteLengths.map((byteLength, index) => {
+      const buffer = createEmptyStorageBuffer(this.device, byteLength, {
+        label: `${label ?? "compute"}-output-${index}`,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+      })
+      bindGroupEntries.push({ binding: outputOffset + index, resource: { buffer } })
+      layoutEntries.push({
+        binding: outputOffset + index,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: { type: "storage" },
+      })
+      return buffer
+    })
+
+    let uniformBuffer: GPUBuffer | undefined
+    if (uniforms) {
+      const uniformBinding = outputOffset + outputBuffers.length
+      uniformBuffer = createUniformBuffer(this.device, uniforms, {
+        label: `${label ?? "compute"}-uniforms`,
+      })
+      bindGroupEntries.push({ binding: uniformBinding, resource: { buffer: uniformBuffer } })
+      layoutEntries.push({
+        binding: uniformBinding,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: { type: "uniform" },
+      })
+    }
+
+    const cacheKey = `${shader}::${layoutEntries.length}::${entryPoint}`
+    let pipeline = this.pipelineCache.get(cacheKey)
+    if (!pipeline) {
+      const module = this.device.createShaderModule({ code: shader })
+      const bindGroupLayout = this.device.createBindGroupLayout({ entries: layoutEntries })
+      pipeline = this.device.createComputePipeline({
+        layout: this.device.createPipelineLayout({ bindGroupLayouts: [bindGroupLayout] }),
+        compute: { module, entryPoint },
+      })
+      this.pipelineCache.set(cacheKey, pipeline)
+    }
+
+    const bindGroup = this.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: bindGroupEntries,
+    })
+
+    const encoder = this.device.createCommandEncoder({ label })
+    const pass = encoder.beginComputePass({ label })
+    pass.setPipeline(pipeline)
+    pass.setBindGroup(0, bindGroup)
+    pass.dispatchWorkgroups(...workgroupCount)
+    pass.end()
+    this.device.queue.submit([encoder.finish()])
+
+    const outputData = await Promise.all(
+      outputBuffers.map((buffer, index) =>
+        readBuffer(this.device, buffer, outputByteLengths[index]),
+      ),
+    )
+
+    outputBuffers.forEach((buffer) => buffer.destroy())
+    inputStorageBuffers.forEach((buffer) => buffer.destroy())
+    uniformBuffer?.destroy()
+
+    return { outputBuffers: outputData }
+  }
+}

--- a/src/lib/webgpu/index.ts
+++ b/src/lib/webgpu/index.ts
@@ -1,0 +1,11 @@
+export { WebGPUComputeCell } from "./computeCell"
+export type { ComputeResult, ComputeSubmission } from "./computeCell"
+export {
+  UNIFORM_ALIGNMENT,
+  alignTo,
+  createEmptyStorageBuffer,
+  createStorageBuffer,
+  createUniformBuffer,
+  readBuffer,
+} from "./buffers"
+export { buildSwarmScoreSubmission, swarmScoreShader } from "./kernels/swarmScore"

--- a/src/lib/webgpu/kernels/swarmScore.ts
+++ b/src/lib/webgpu/kernels/swarmScore.ts
@@ -1,0 +1,46 @@
+import type { ComputeSubmission } from "../computeCell"
+
+export const swarmScoreShader = `
+struct Agent {
+  position: vec2<f32>,
+  velocity: vec2<f32>,
+}
+
+struct Weights {
+  positionWeight: f32,
+  velocityWeight: f32,
+}
+
+@group(0) @binding(0) var<storage, read> agents: array<Agent>;
+@group(0) @binding(1) var<storage, read_write> scores: array<f32>;
+@group(0) @binding(2) var<uniform> weights: Weights;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+  let index = id.x;
+  if (index >= arrayLength(&agents)) {
+    return;
+  }
+
+  let agent = agents[index];
+  let positionScore = length(agent.position) * weights.positionWeight;
+  let velocityScore = length(agent.velocity) * weights.velocityWeight;
+  scores[index] = positionScore + velocityScore;
+}
+`
+
+export function buildSwarmScoreSubmission(
+  agents: Float32Array,
+  agentCount: number,
+  weights: { positionWeight: number; velocityWeight: number },
+): ComputeSubmission {
+  const uniformData = new Float32Array([weights.positionWeight, weights.velocityWeight])
+  return {
+    inputBuffers: [agents],
+    outputByteLengths: [agentCount * Float32Array.BYTES_PER_ELEMENT],
+    shader: swarmScoreShader,
+    uniforms: uniformData,
+    workgroupCount: [Math.ceil(agentCount / 64), 1, 1],
+    label: "swarm-score",
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a headless, non-visual WebGPU primitive to perform high-throughput numeric computation beneath the Legs layer. 
- Enforce clean data boundaries and avoid GPU/UI coupling by exposing a single `submit` primitive for compute workloads. 
- Ship an example kernel for immediate non-visual use (swarm scoring) so higher layers can adopt the pattern quickly.

### Description

- Add a `WebGPUComputeCell` in `src/lib/webgpu/computeCell.ts` implementing `submit({ inputBuffers, outputByteLengths, shader, uniforms, workgroupCount })` with pipeline caching and deterministic binding layout. 
- Add strict buffer IO helpers in `src/lib/webgpu/buffers.ts` including aligned uniform creation, storage buffer creation, and safe readback via `readBuffer`. 
- Provide a non-visual example kernel `swarmScore` and a `buildSwarmScoreSubmission` helper in `src/lib/webgpu/kernels/swarmScore.ts`. 
- Expose the compute cell via `src/lib/webgpu/index.ts` and a Legs capability wrapper `createWebGPUComputeCell` in `src/lib/legs/*`, plus documentation in `docs/WIRED_CHAOS_WEBGPU_COMPUTE_CELL.md` describing the API and binding contract.

### Testing

- No automated tests were executed as part of this change; no build or runtime validation was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6974df6797848327a17fbe6c478c884a)