### PR TITLE
ci: use npm install instead of npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 20
           cache: 'npm'
       - name: Install dependencies
-        run: npm ci
+        run: npm install
       - name: Generate Prisma client
         run: npx prisma generate
       - name: Build project
@@ -43,7 +43,7 @@ jobs:
           node-version: 20
           cache: 'npm'
       - name: Install dependencies
-        run: npm ci
+        run: npm install
       - name: NPM audit (high/critical)
         run: npm audit --production --audit-level=high
       - name: Trivy filesystem scan

--- a/.github/workflows/security-sweep.yml
+++ b/.github/workflows/security-sweep.yml
@@ -31,7 +31,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Generate Prisma client
         run: npx prisma generate


### PR DESCRIPTION
### Motivation
- Replace `npm ci` with `npm install` in CI workflows so dependency installation does not require a `package-lock.json` and mobile contributors (or repos without a lockfile) can run CI successfully.

### Description
- Replaced `npm ci` with `npm install` in `.github/workflows/ci.yml` and `.github/workflows/security-sweep.yml` and committed the change with message `ci: use npm install instead of npm ci`.

### Testing
- No automated tests were executed locally; the updated workflows will be validated when GitHub Actions runs the install/build/audit jobs on the branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6974e09d683c8327b9ad1914560804df)