### PR TITLE
Add Dual-Substrate Hosting Model: VPS Execution Layer + Evernode Sovereign Trust Layer

### DIFF
--- a/docs/WIRED_CHAOS_DUAL_SUBSTRATE_HOSTING.md
+++ b/docs/WIRED_CHAOS_DUAL_SUBSTRATE_HOSTING.md
@@ -1,0 +1,128 @@
+# Dual-Substrate Hosting Model
+
+## Title
+Add Dual-Substrate Hosting Model: VPS Execution Layer + Evernode Sovereign Trust Layer for WIRED CHAOS META
+
+## Summary
+This document formalizes a dual-substrate infrastructure model for WIRED CHAOS META:
+
+- VPS-based infrastructure for continuous execution, gateways, and heavy workloads.
+- Evernode-based infrastructure for trust anchoring, patch receipts, agent attestation, and canonical signaling.
+
+Together, they define a system where execution remains scalable and flexible, while trust is verifiable and minimized.
+
+## Motivation
+WIRED CHAOS META requires both:
+
+- Reliable, always-on execution environments.
+- A system-wide mechanism for verifiable truth, provenance, and governance.
+
+Traditional VPS environments excel at execution but rely on implicit trust. Evernode excels at trust and coordination but is not suited for heavy compute or UI. This model separates the concerns and integrates both as first-class layers.
+
+## Scope of Changes
+
+### 1) VPS Execution Layer (Newly Formalized)
+Define VPS infrastructure as the Primary Execution Layer, responsible for:
+
+- Long-running gateways (e.g., Clawdbot Gateway).
+- Agent runtime environments.
+- API endpoints and WebSocket services.
+- Background workers and schedulers.
+- Persistent workspace/state storage.
+
+Supported environments include:
+
+- Hetzner / AWS / Fly.io / Railway / exe.dev.
+- Docker or VM-based deployments.
+
+VPS nodes are treated as mutable, replaceable, and scalable.
+
+### 2) Evernode Sovereign Layer (Anchoring & Verification)
+Evernode is defined as the Sovereign Trust & Coordination Layer, responsible for:
+
+- Agent identity attestation.
+- Patch registration and receipts.
+- Canonical signal timestamps.
+- Anti-sybil and stake-backed verification.
+- Cross-app coordination truth.
+
+Evernode hosts Sentinel Agents only (no heavy compute).
+
+### 3) VPS ↔ Evernode Bridge Protocol
+Introduce a signed event bridge:
+
+- VPS-based agents emit signed events.
+- Events are observed and acknowledged by Evernode Sentinels.
+- Evernode issues receipts (hash, time, identity, scope).
+- VPS agents continue execution regardless, but trust state updates system-wide.
+
+This preserves uptime while enabling verification.
+
+### 4) Patch Lifecycle Enforcement
+Patches follow a system-wide lifecycle:
+
+- Declared on VPS.
+- Registered on Evernode.
+- Executed on VPS.
+- Attested by Evernode.
+- Revocable or sandboxed if trust is lost.
+
+Unregistered patches remain functional but flagged as unverified.
+
+### 5) Application Integration
+Standalone apps (Akira Codex, NPC, FEN, Tax Suite, Trust Suite):
+
+- Run on VPS or Vercel.
+- Periodically check in with Evernode.
+- Reference canonical state without direct coupling.
+- Share truth without sharing infrastructure.
+
+### 6) Swarm Room / CHAOS OS Semantics
+CHAOS OS treats:
+
+- VPS nodes as execution hardware.
+- Evernode as constitutional hardware.
+
+The Swarm Room UI reflects:
+
+- Verified vs unverified agents.
+- Trusted vs sandboxed patches.
+- Canonical vs ephemeral signals.
+
+Infrastructure remains invisible to end users.
+
+## Out of Scope (Explicit)
+- Moving UI or heavy compute to Evernode.
+- Replacing VPS with decentralized hosting.
+- Forcing Evernode registration for local dev.
+
+## Architecture Impact
+This model establishes a clean separation of concerns:
+
+- Execution can scale, fail, or be replaced.
+- Trust remains continuous and auditable.
+
+The system becomes:
+
+- More resilient.
+- More governable.
+- Institution-compatible.
+- Adversary-aware.
+
+## Backward Compatibility
+No breaking changes. Existing VPS deployments continue unchanged. Evernode integration is additive and opt-in at first.
+
+## Next Steps (Follow-Up PRs)
+- VPS node classification (trusted / provisional / ephemeral).
+- Sentinel Agent spec.
+- Patch receipt schema finalization.
+- Automated quarantine rules.
+- NEXUS PUBLICA trust bridge.
+
+## Review Focus
+Reviewers should evaluate:
+
+- VPS ↔ Evernode trust boundaries.
+- Failure modes (VPS down, Evernode unreachable).
+- Signature and receipt flow.
+- Minimal coupling guarantees.


### PR DESCRIPTION
### Motivation
- WIRED CHAOS META requires always-on execution environments and a separate verifiable trust/coordination substrate to ensure provenance and governance.
- The change separates execution concerns (scale, mutability) from trust concerns (attestation, receipts) to reduce coupling and systemic friction.
- The document provides a clear operational spine to guide integration, review, and follow-up work such as sentinel specs and receipt schemas.

### Description
- Add `docs/WIRED_CHAOS_DUAL_SUBSTRATE_HOSTING.md` which formalizes the dual-substrate model and describes VPS execution, Evernode sovereign trust, the VPS↔Evernode bridge, patch lifecycle, application integration, Swarm Room semantics, and review focus.
- Define VPS as the primary execution substrate for long-running gateways, agent runtimes, API/WebSocket endpoints, background workers, and persistent state, and list supported deployment environments.
- Define Evernode as the sovereign trust and coordination layer responsible for agent identity attestation, patch registration/receipts, canonical timestamps, anti-sybil measures, and hosting Sentinels only.
- Introduce a signed event bridge pattern and a patch lifecycle where patches are declared on VPS, registered and attested on Evernode, executed on VPS, and can be flagged or sandboxed if unverified.

### Testing
- No automated tests were added or run because this is a documentation-only change.
- The existing repository test/CI configuration was not modified and is expected to remain unaffected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6975de20287483278af9462e0fe6af33)