### PR TITLE
Add wired-chaos-stack pnpm workspace scaffold

### DIFF
--- a/wired-chaos-stack/package.json
+++ b/wired-chaos-stack/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "wired-chaos-stack",
+  "private": true,
+  "packageManager": "pnpm@9.12.1",
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "lint": "echo 'No lint configured yet'",
+    "test": "echo 'No tests configured yet'"
+  }
+}

--- a/wired-chaos-stack/packages/dyad/README.md
+++ b/wired-chaos-stack/packages/dyad/README.md
@@ -1,0 +1,3 @@
+# dyad
+
+Canonical backend service for rules and triggers.

--- a/wired-chaos-stack/packages/dyad/package.json
+++ b/wired-chaos-stack/packages/dyad/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@wired-chaos/dyad",
+  "version": "0.0.0",
+  "private": true
+}

--- a/wired-chaos-stack/packages/lovable-web/README.md
+++ b/wired-chaos-stack/packages/lovable-web/README.md
@@ -1,0 +1,3 @@
+# lovable-web
+
+UI that talks to Dyad (portable to Lovable).

--- a/wired-chaos-stack/packages/lovable-web/package.json
+++ b/wired-chaos-stack/packages/lovable-web/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@wired-chaos/lovable-web",
+  "version": "0.0.0",
+  "private": true
+}

--- a/wired-chaos-stack/packages/rails-clawpump/README.md
+++ b/wired-chaos-stack/packages/rails-clawpump/README.md
@@ -1,0 +1,3 @@
+# rails-clawpump
+
+Solana pump.fun launch wrapper (HTTP API).

--- a/wired-chaos-stack/packages/rails-clawpump/package.json
+++ b/wired-chaos-stack/packages/rails-clawpump/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@wired-chaos/rails-clawpump",
+  "version": "0.0.0",
+  "private": true
+}

--- a/wired-chaos-stack/packages/rails-moltlaunch/README.md
+++ b/wired-chaos-stack/packages/rails-moltlaunch/README.md
@@ -1,0 +1,3 @@
+# rails-moltlaunch
+
+Base token deploy wrapper (CLI).

--- a/wired-chaos-stack/packages/rails-moltlaunch/package.json
+++ b/wired-chaos-stack/packages/rails-moltlaunch/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@wired-chaos/rails-moltlaunch",
+  "version": "0.0.0",
+  "private": true
+}

--- a/wired-chaos-stack/packages/shared/README.md
+++ b/wired-chaos-stack/packages/shared/README.md
@@ -1,0 +1,3 @@
+# shared
+
+Shared types and OpenAPI schemas.

--- a/wired-chaos-stack/packages/shared/package.json
+++ b/wired-chaos-stack/packages/shared/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@wired-chaos/shared",
+  "version": "0.0.0",
+  "private": true
+}

--- a/wired-chaos-stack/pnpm-workspace.yaml
+++ b/wired-chaos-stack/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"


### PR DESCRIPTION
### Motivation
- Provide an initial pnpm workspace layout for the `wired-chaos-stack` monorepo to standardize package structure and onboarding.
- Include placeholder packages and minimal manifests so downstream work can add implementations incrementally.

### Description
- Add root workspace manifest `wired-chaos-stack/package.json` with `workspaces` pointing to `packages/*` and basic `lint`/`test` scripts.
- Add `wired-chaos-stack/pnpm-workspace.yaml` to declare workspace package paths.
- Add a shared environment example `wired-chaos-stack/.env.example` with a `NODE_ENV` default.
- Create placeholder packages under `wired-chaos-stack/packages/` for `dyad`, `lovable-web`, `rails-moltlaunch`, `rails-clawpump`, and `shared`, each with a minimal `package.json` and `README.md`.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698261ff75388327aedb675ac5801a30)