### PR TITLE
Add root-level portfolio skill invariant, PORTFOLIO.md, and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Summary
+- 
+
+## Skill Proof Requirement
+Every build in this repository must demonstrate or document usage of the following skills.
+
+- [ ] **Claude Code**
+  - Proof:
+- [ ] **Claude API**
+  - Proof:
+- [ ] **MCP Servers**
+  - Proof:
+- [ ] **Agent Orchestration**
+  - Proof:
+- [ ] **Automation**
+  - Proof:
+- [ ] **Linux**
+  - Proof:
+- [ ] **TypeScript**
+  - Proof:
+- [ ] **Fractal Claude Clusters**
+  - Proof:
+
+> PRs missing skill proof may be closed without review.
+
+## Validation
+- [ ] Local checks completed
+- [ ] Relevant docs updated

--- a/PORTFOLIO.md
+++ b/PORTFOLIO.md
@@ -1,0 +1,37 @@
+# Portfolio Skill Proof Requirement
+
+Every build and pull request in this repository must include explicit proof (implementation links or documentation evidence) for the required portfolio skill set.
+
+## Required skills
+- Claude Code
+- Claude API
+- MCP Servers
+- Agent Orchestration
+- Automation
+- Linux
+- TypeScript
+- Fractal Claude Clusters
+
+## Evidence checklist
+Use this checklist in every PR (or reference the same sections from your PR description):
+
+- [ ] **Claude Code**
+  - Proof:
+- [ ] **Claude API**
+  - Proof:
+- [ ] **MCP Servers**
+  - Proof:
+- [ ] **Agent Orchestration**
+  - Proof:
+- [ ] **Automation**
+  - Proof:
+- [ ] **Linux**
+  - Proof:
+- [ ] **TypeScript**
+  - Proof:
+- [ ] **Fractal Claude Clusters**
+  - Proof:
+
+## Reviewer guidance
+- PRs that do not include skill proof may be closed without review.
+- Proof can be code paths, workflow runs, docs references, or architecture notes.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 WIRED CHAOS WORKFLOW PUBLISH CODEX
 
+## Portfolio Skill Invariant
+This repository enforces a root-level portfolio invariant: every merged build must demonstrate or document evidence for the required skill set.
+
+Required skill set:
+- Claude Code
+- Claude API
+- MCP Servers
+- Agent Orchestration
+- Automation
+- Linux
+- TypeScript
+- Fractal Claude Clusters
+
+Implementation and proof policy:
+- Canonical checklist and proof format: [`PORTFOLIO.md`](PORTFOLIO.md)
+- Pull request enforcement template: [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md)
+
+PRs missing skill proof may be closed without review.
+
 ## Structure
 - `README.md`: Brief label for the repository and quick pointers.
 - `DIAGNOSTIC.md`: Current snapshot of repository layout, status, and recommended next steps.


### PR DESCRIPTION
### Motivation
- Make the required skill set a repository-level contract rather than a per-project preference so contributors and reviewers see it at the root. 
- Standardize how contributors provide proof of competency for core capabilities (Claude Code, Claude API, MCP Servers, Agent Orchestration, Automation, Linux, TypeScript, Fractal Claude Clusters). 
- Improve reviewer efficiency by surfacing a canonical evidence location and an enforceable PR checklist.

### Description
- Add a `Portfolio Skill Invariant` section to `README.md` that lists the required skills and links to canonical proof locations. 
- Add `PORTFOLIO.md` containing the required skill set, an evidence checklist, and reviewer guidance. 
- Add `.github/PULL_REQUEST_TEMPLATE.md` with a standardized `Skill Proof Requirement` checklist and a short validation block. 
- Document the enforcement posture that `PRs missing skill proof may be closed without review` to guide maintainers and contributors.

### Testing
- Ran `git diff --check -- README.md PORTFOLIO.md .github/PULL_REQUEST_TEMPLATE.md` to validate diffs and spacing, and it completed without errors. 
- Applied and committed the changes with `git commit` which recorded the new files and README modifications successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ae76d09bc83279ecbd96db6f18cd9)