### PR TITLE
Add minimal redledger relay API scaffold

### DIFF
--- a/redledger-relay/api/redledger/capture.ts
+++ b/redledger-relay/api/redledger/capture.ts
@@ -1,0 +1,9 @@
+export default function handler(req, res) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  return res.status(200).json({ success: true });
+}

--- a/redledger-relay/api/redledger/events.ts
+++ b/redledger-relay/api/redledger/events.ts
@@ -1,0 +1,4 @@
+export default function handler(req, res) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.status(200).json({ events: [] });
+}

--- a/redledger-relay/api/redledger/flags.ts
+++ b/redledger-relay/api/redledger/flags.ts
@@ -1,0 +1,8 @@
+export default function handler(req, res) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.status(200).json({
+    skyTint: "#0a0a0f",
+    volatility: 1,
+    spawnRateMultiplier: 1
+  });
+}

--- a/redledger-relay/api/redledger/state.ts
+++ b/redledger-relay/api/redledger/state.ts
@@ -1,0 +1,15 @@
+export default function handler(req, res) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.status(200).json({
+    worldVersion: 1,
+    globalSignal: 50,
+    nodes: [
+      { id: "node-0", captured: false },
+      { id: "node-1", captured: false },
+      { id: "node-2", captured: false },
+      { id: "node-3", captured: false },
+      { id: "node-4", captured: false }
+    ],
+    factions: [{ id: "SOVEREIGN", power: 1 }]
+  });
+}

--- a/redledger-relay/api/redledger/stream.ts
+++ b/redledger-relay/api/redledger/stream.ts
@@ -1,0 +1,16 @@
+export default function handler(req, res) {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+    "Access-Control-Allow-Origin": "*"
+  });
+
+  const interval = setInterval(() => {
+    res.write(`data: ${JSON.stringify({ tick: Date.now() })}\n\n`);
+  }, 5000);
+
+  req.on("close", () => {
+    clearInterval(interval);
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, stateless relay "brain" service to act as an independent authority for Redledger clients.
- Implement a backend-only `/api/redledger` surface that exposes state, events, flags, a capture endpoint, and an SSE stream so clients can bootstrap against a simple, dedicated relay.

### Description
- Add new folder `redledger-relay/api/redledger` with five endpoints: `state.ts`, `events.ts`, `flags.ts`, `capture.ts`, and `stream.ts`.
- Each endpoint sets CORS header `Access-Control-Allow-Origin: *` and returns the fixed JSON payloads as specified by the starter template.
- `capture.ts` enforces POST-only behavior, returning `405` for non-POST methods and `200` with `{ success: true }` for valid requests.
- `stream.ts` implements a basic SSE stream that writes `data: {...}` ticks every 5 seconds and clears the interval on `req.on("close")`.

### Testing
- Created and committed the new files and the commit completed successfully via `git commit`.
- Verified the files exist with `find redledger-relay/api/redledger -maxdepth 1 -type f | sort`, which listed the five endpoints.
- Inspected file contents with `nl` and `git show` to confirm handler implementations; no runtime deploy or integration tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699bd7e877d08327ab0c6e5c0afbcc0f)