### PR TITLE
docs: add CoPaw contribution playbook for WIRED CHAOS contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ PRs missing skill proof may be closed without review.
 - `README.md`: Brief label for the repository and quick pointers.
 - `DIAGNOSTIC.md`: Current snapshot of repository layout, status, and recommended next steps.
 - `docs/AGENTIC_UI_INGESTION_PIPELINE.md`: Agentic UI ingestion pipeline and Transmission Frame compiler spec.
+- `docs/COPAW_CONTRIBUTION_PLAYBOOK.md`: Step-by-step guide for contributing WIRED CHAOS-aligned updates to the CoPaw OSS repository.
 
 ## Canonical architecture (WIRED CHAOS META)
 The canonical architecture baseline is formalized in `/doc` and serves as the non-runtime authority for policy boundaries, trust handling, ingress constraints, and execution contracts.

--- a/docs/COPAW_CONTRIBUTION_PLAYBOOK.md
+++ b/docs/COPAW_CONTRIBUTION_PLAYBOOK.md
@@ -1,0 +1,94 @@
+# CoPaw Contribution Playbook (NEURO / WIRED CHAOS META)
+
+This playbook captures a practical, repeatable workflow for contributing to the Apache-2.0 `agentscope-ai/CoPaw` repository from a WIRED CHAOS META context.
+
+## 1) Fork the upstream repository
+
+- Navigate to `https://github.com/agentscope-ai/CoPaw`.
+- Select **Fork** (top-right) to create your own copy.
+
+## 2) Clone your fork
+
+```bash
+git clone https://github.com/<your-username>/CoPaw.git
+cd CoPaw
+```
+
+## 3) Create a focused branch
+
+Use an isolated branch for each contribution:
+
+```bash
+git checkout -b feature/neuro-meta-x
+```
+
+Suggested branch naming patterns:
+
+- `feature/<capability-name>`
+- `doc/<topic-name>`
+- `fix/<issue-name>`
+
+## 4) Implement your change
+
+Target directories by change type:
+
+- `src/copaw` for core Python behavior
+- `website` for front-end/UI updates
+- `scripts/*` for CLI and automation
+- `tests` for test coverage
+- `website/public/docs` for project documentation
+
+Examples of meaningful WIRED CHAOS-aligned contributions:
+
+- Modular integration points for NEURO META X orchestration patterns
+- Adapter modules for agent interoperability
+- Integration documentation and end-to-end workflow guides
+- Unit tests that validate extension contracts
+
+## 5) Install dependencies and run checks
+
+```bash
+pip install -e .
+pip install -e ".[dev]"
+```
+
+Then execute the checks documented by CoPaw's `CONTRIBUTING.md` and verify your update is stable.
+
+## 6) Commit and push
+
+```bash
+git add .
+git commit -m "feat: add NEURO META X integration blueprint"
+git push origin feature/neuro-meta-x
+```
+
+Use clear commit messages that describe both **what** changed and **why** it matters.
+
+## 7) Open a pull request
+
+From your fork on GitHub, select **Compare & pull request**.
+
+A strong PR description should include:
+
+- A concise summary of the change
+- The user or system impact
+- References to linked issues/specs
+- Evidence of tests and docs updates
+
+## High-signal PR checklist
+
+- Follow upstream `CONTRIBUTING.md` conventions.
+- Add tests when behavior changes.
+- Add or update docs for discoverability.
+- Keep formatting/lint/style consistent with the codebase.
+
+## Strategic WIRED CHAOS contribution ideas
+
+When contributing from WIRED CHAOS META, prioritize modular increments:
+
+- `copaw_ext/neuro_meta_x` plugin scaffold
+- Skill interface exposing WIRED CHAOS agent patterns
+- Integration docs mapping orchestrator boundaries and flows
+- Unit tests for extension correctness and regression safety
+
+Contributing in these increments keeps reviews tractable while increasing ecosystem interoperability.


### PR DESCRIPTION
### Motivation
- Provide a clear, repeatable contribution workflow for integrating WIRED CHAOS / NEURO-style changes into the Apache-2.0 `agentscope-ai/CoPaw` repo.
- Improve discoverability by surfacing actionable branch/commit/PR steps and recommended contribution patterns for modular interoperability.

### Description
- Add `docs/COPAW_CONTRIBUTION_PLAYBOOK.md` containing a step-by-step guide (fork, clone, branch, implement, test, commit, PR) and strategic contribution ideas (plugin scaffold, skill interface, integration docs, tests).
- Update `README.md` to include a pointer to the new playbook in the repository structure section for discoverability.
- Changes committed on the current branch as `docs: add CoPaw contribution playbook` and prepared for PR submission.

### Testing
- No automated tests were run because this is a documentation-only change; no runtime code paths were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a6578c93508327b13181bce0595064)