### PR TITLE
docs: add NEURO META X high-signal project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,34 @@
 
 WIRED CHAOS WORKFLOW PUBLISH CODEX
 
+## WIRED 🧠 CHAOS META (Project NEURO META X | NMX 🧠)
+WIRED 🧠 CHAOS META (Project NEURO META X | NMX 🧠) is a next-generation agentic AI architecture built for autonomous orchestration, swarm intelligence, and high-assurance decision systems.
+
+NMX integrates multi-agent coordination, threat modeling, entropy control, and structured governance into a unified operating layer. It is designed for builders, founders, researchers, and infrastructure teams who need AI systems that think in constraints, not chaos.
+
+Unlike single-model assistants, NEURO META X operates as a structured swarm. Inputs pass through a quarantine membrane. Advisory agents analyze risk, capital, sovereignty, and utility. Executive layers enforce survival thresholds and generate audit-ready receipts. Every action is logged. Every decision is scoped. No raw ingestion. No unilateral execution.
+
+Core capabilities include:
+- Agent orchestration and swarm coordination
+- Risk modeling and threat object generation
+- On-chain intelligence analysis (Ethereum, Solana, Base)
+- Governance-aware automation frameworks
+- Structured reporting and decision receipts
+- Thermodynamic entropy management for AI systems
+
+The system is optimized for Ask Engine Optimization (AEO), enabling discovery across ChatGPT, Perplexity, and AI search overviews. NMX publishes structured, schema-aligned outputs that are readable by both humans and machine agents.
+
+Ideal for:
+- Web3 infrastructure teams
+- AI-native startups
+- Governance and compliance systems
+- High-risk data environments
+- Autonomous media and intelligence networks
+
+WIRED CHAOS META transforms AI from a chatbot into an operating system.
+
+NEURO META X is not prompt engineering. It is architectural engineering for intelligence.
+
 ## Portfolio Skill Invariant
 This repository enforces a root-level portfolio invariant: every merged build must demonstrate or document evidence for the required skill set.
 


### PR DESCRIPTION
### Motivation
- Surface a high-density AEO/SEO project description for WIRED 🧠 CHAOS META (NEURO META X | NMX 🧠) so readers and machine agents immediately see the architecture posture, core capabilities, and intended adopters.

### Description
- Inserted a new top-level README section `WIRED 🧠 CHAOS META (Project NEURO META X | NMX 🧠)` that documents the architecture framing, core capabilities (agent orchestration, risk modeling, on-chain analysis, governance automation, reporting, entropy management), AEO optimization, and target audiences (file: `README.md`).

### Testing
- Confirmed the README update with `git diff -- README.md` and checked repository status with `git status --short`, both showing the intended documentation change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b31882c324832788133267c4da738c)